### PR TITLE
Integrate divergent schema-fns work: Validator class + typed errors + namespaced validators (1.0.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,9 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+
+# Private/local-only notes (may reference private repos)
+*.local.md
+
+# Git worktrees
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -1,349 +1,264 @@
 # schema-fns
-Composable schema functions for input transformation and validation
 
-## Installation
+Composable schema functions for input transformation and validation.
 
-``` sh
+## Install
+
+```sh
 npm install schema-fns
 ```
 
+ESM only; Node 22+.
+
 ## Overview
 
-`schema-fns` lets you build composable schemas for input transformation and
-validation. The most important export is the `schema()` function that's used to
-define schemas. It's modeled after the Express middleware model of layers of
-handler functions and therefore accepts as parameters any number of functions or
-schema objects. Those functions have a signature of `(value, update, error)`,
-where:
-- `value` is the input value to be transformed and validated, 
-- `update` is a function used to return a modified input value, and
-- `error` is a function used to create validation errors.
+Build schemas by composing `Validator` instances. Every primitive
+(`type`, `required`, `string.url`, `number.min`, etc.) returns a
+`Validator`. `schema()`, `key()`, and `items()` compose validators into
+larger ones.
 
-## Input transformation
+```js
+import {
+  schema, key, required, type, string, number,
+} from "schema-fns";
 
-Let's see it in action. The first thing you can do with `schema-fns` is
-transform input. The following example uses two transformation functions, one
-to convert the value to a string, and another to append a `"1"`. Given the input
-`42`, the value becomes `"421"`:
-
-``` js
-const { schema } = require("schema-fns");
-
-const MySchema = schema(
-  function (value, update, error) {
-    update(String(value));
-  },
-  function (value, update, error) {
-    update(value + "1");
-  },
+const UserSchema = schema(
+  type(Object),
+  key("name", required(), string.minLength(1), string.maxLength(100)),
+  key("age", required(), number.integer(), number.nonNegative()),
 );
 
-const { value } = MySchema.validate(42);
-console.log(value); //=> "421"
+const result = UserSchema.validate({ name: "Alice", age: 30 });
+result.valid; // true
+result.value; // { name: "Alice", age: 30 }
 ```
 
-For simple value tranformations, there's an adapter function `mapAdapter()` that
-converts mapping functions to a form that works for `schema-fns`. The same
-example above can be written as:
+## `Validator`
 
-``` js
-const { schema, mapAdapter } = require("schema-fns");
+Every primitive returns a `Validator`. A schema is just a `Validator`
+built from other validators.
 
-const MySchema = schema(
-  mapAdapter(value => String(value)),
-  mapAdapter(value => value + "1"),
+### `.validate(value)` / `.validateAsync(value)`
+
+Returns a `ValidationResult`. On success, `{ valid: true, value }`. On
+failure, `{ valid: false, errors }`. `errors` is an array of
+`ValidationError` (or subclass) instances, each with a `path` describing
+where in the input the failure happened.
+
+### `.test(value)` / `.testAsync(value)`
+
+Returns a boolean.
+
+### `.assert(value)` / `.assertAsync(value)`
+
+Returns the successful `ValidationResult`, or throws a `ValidationError`
+whose `.errors` is the full error list.
+
+### `.message(stringOrFunction)`
+
+Replaces the default message on any error the validator produces.
+Chainable; returns `this`.
+
+```js
+const Age = number.integer().message("Age must be a whole number.");
+```
+
+With a function, you get access to the full error for interpolation:
+
+```js
+const Min = minLength(3).message(
+  (error) => `must be at least ${error.details.minLength} characters`,
 );
-
-const { value } = MySchema.validate(42);
-console.log(value); //=> "421"
 ```
 
-## Input validation
+## Composing schemas
 
-The next interesting thing you can do is validate input values. And the simplest
-way is to use built-in validation functions. Calling `.validate(input)` returns
-an object with:
-- `valid`: `true` if there were no validation errors, `false` otherwise
-- `value`: the transformed value
-- `errors`: an array of any validation errors
+### `schema(...validators)`
 
-### `.validate(value)`
+Runs each validator in order. Accumulates errors; returns the
+transformed `value` if all pass.
 
-Here's an example that validates that a value is an object.
+### `key(name, ...validators)`
 
-``` js
-const { schema, is } = require("schema-fns");
+Focuses on a property of an object. Errors are emitted with
+`path = [name, ...inner.path]`.
 
-const MySchema = schema(
-  is(Object),
-);
+### `items(...validators)`
 
-const { valid, value, errors } = MySchema.validate(42);
-console.log(valid); //=> false
-console.log(value); //=> 42 (because the value was never updated)
+Validates every item in an array. Errors are emitted with
+`path = [index, ...inner.path]`. Fails if the value isn't an array.
+
+### `hasKey(name)`
+
+Requires a key to be present (with a non-`undefined` value). Supports
+string or symbol keys. Throws `MissingKeyError`.
+
+## Presence
+
+### `required(...validators)`
+
+Fails (`RequiredError`) if the value is missing. Missing means `null`,
+`undefined`, `NaN`, empty string, length-0 array/string, size-0
+Map/Set, or any value `isEmpty()` treats as empty. If present, runs the
+inner validators.
+
+### `optional(...validators)`
+
+Passes without running inner validators if the value is `undefined`,
+`null`, or `""`. Otherwise runs them.
+
+### `isEmpty(value)`
+
+Primitives are never empty. Arrays/strings check `.length`. Maps/Sets
+check `.size`. Iterables check for any item. Plain objects check for
+any enumerable property.
+
+## Types
+
+### `type(Type)`
+
+Passes if the value matches `Type`. Accepts:
+
+- strict equality (for `null`/`undefined`)
+- `value instanceof Type` (for classes)
+- `typeof value === Type` (for strings like `"string"`)
+- `typeof value === Type.name.toLowerCase()` (for primitive
+  constructors like `String`, `Number`)
+
+Throws `WrongTypeValidationError`.
+
+### `type.oneOf(...Types)`
+
+Passes if `value instanceof` any of the given types.
+
+### `type.to(Type)`
+
+Coerces the value to a target type. Built-in conversions for `Array`,
+`BigInt`, `Boolean`, `Date`, `Function`, `Map`, `Number`, `Object`,
+`Promise`, `RegExp`, `Set`, `String`, `Symbol`, `Uint8Array`. Unknown
+types are called as `Type(value)`.
+
+```js
+const parseAge = type.to(Number);
+parseAge.validate("42").value; // 42
 ```
 
-The `errors` array will look like the following:
+### `oneOf(...values)`
 
-``` js
-[{
-  code: "is.type", // the validation error code
-  path: [], // path taken to get from the input to the value where the error happened
-  message: "wrong type: expected object", // the default
-  value: 42, // the value validated
-  expectedType: "object", // each validator may include additional context
-}]
+Passes if `value` is included in the given values.
+
+## Strings
+
+```js
+string();                 // type(String)
+string.minLength(n);      // throws MinimumStringLengthError
+string.maxLength(n);      // throws MaximumStringLengthError
+string.url();             // throws InvalidURLError
+string.email();           // throws InvalidEmailError
+string.isoDate();         // throws InvalidISODateError (YYYY-MM-DD)
 ```
 
-### `.test(value)`
+`string.url()` accepts bare domains (`"example.com"`), rejects IPs and
+unlisted domains. `string.isoDate()` rejects format mismatches and
+invalid calendar dates (e.g. `2024-02-30`).
 
-In addition to `.validate()`, there is a `.test()` function that just returns
-the value of `valid`:
+## Numbers
 
-``` js
-const { schema, is } = require("schema-fns");
-
-const MySchema = schema(
-  is(Object),
-);
-
-console.log(MySchema.test(42)); //=> false
-console.log(MySchema.test({})); //=> true
-console.log(MySchema.test("hi")); //=> false
+```js
+number();                 // type(Number)
+number.min(n);            // throws MinimumNumberError
+number.max(n);            // throws MaximumNumberError
+number.finite();          // throws FiniteNumberError
+number.integer();         // throws NonIntegerError
+number.positive();        // > 0, throws PositiveNumberError
+number.nonNegative();     // >= 0, throws NonNegativeNumberError
 ```
 
-### `.assert(value)`
+## Length
 
-Finally, if instead of receiving the transformed value and errors, `.assert()`
-will throw an error if validation fails:
+### `minLength(n)`
 
-``` js
-const { schema, is } = require("schema-fns");
+Generic length check; works on any value with a numeric `.length`.
+Throws `MinLengthError`. Distinct from `string.minLength`, which also
+asserts string-specific behavior.
 
-const MySchema = schema(
-  is(Object),
-);
+## Custom validators
 
-MySchema.assert(42); // throws
-MySchema.assert("hi"); // throws
-MySchema.assert({}); // doesn't throw
-```
+Subclass `Validator` or pass a function to its constructor. Throw a
+`ValidationError` (or subclass) to fail validation. Any other thrown
+value bubbles out of `.validate()`.
 
-### `hasKeys(...keyNames)`
+```js
+import { Validator, ValidationError } from "schema-fns";
 
-Let's look at more validation functions. `hasKeys()` checks that keys are
-present on some object:
-
-``` js
-const { schema, hasKeys } = require("schema-fns");
-
-const MySchema = schema(
-  hasKeys("foo", "bar"),
-);
-
-const { valid, value, errors } = MySchema.validate({});
-console.log(valid); //=> false
-console.log(value); //=> {}
-```
-
-The `errors` array will look like:
-
-``` js
-[{
-  code: "key.missing",
-  path: [],
-  message: `expected key "foo" missing`,
-  key: "foo",
-  value: {},
-}, {
-  code: "key.missing",
-  path: [],
-  message: `expected key "bar" missing`,
-  key: "bar",
-  value: {},
-}]
-```
-
-### `key(name, ...fns)`
-
-The `key()` function is used to focus in on one key of an object and apply
-schema functions to it. The first argument is the key name and the remaining
-arguments are schema functions.
-
-``` js
-const { schema, key, mapAdapter } = require("schema-fns");
-
-const MySchema = schema(
-  key(
-    "name",
-    mapAdapter(value => `Hello, ${value}!`),
-    mapAdapter(value => String(value).toUpperCase()),
-  ),
-);
-
-const { valid, value, errors } = MySchema.validate({ name: "World" });
-
-console.log(valid); //=> true
-console.log(value); //=> { "name": "HELLO, WORLD!" }
-console.log(errors); //=> []
-```
-
-It can also be used for validation:
-
-``` js
-const { schema, is, key } = require("schema-fns");
-
-const MySchema = schema(
-  key("foo", is(Object)),
-);
-
-const { valid, value, errors } = MySchema.validate({ foo: 42 });
-console.log(valid); //=> false
-console.log(value); //=> { foo: 42 }
-```
-
-The `errors` array will look like:
-
-``` js
-[{
-  code: "is.type",
-  path: ["foo"],
-  message: "wrong type: expected object",
-  expectedType: "object",
-  value: 42,
-}]
-```
-
-Of course, `key()` is recursive:
-
-``` js
-const { schema, is, key } = require("schema-fns");
-
-const MySchema = schema(
-  key(
-    "name",
-    is(Object),
-    key("first", is(String)),
-  ),
-);
-
-const { valid, value, errors } = MySchema.validate({
-  name: {
-    first: 42,
-  },
+const evenNumber = new Validator((value) => {
+  if (value % 2 !== 0) {
+    throw new ValidationError({
+      message: "Must be even",
+      details: { value },
+    });
+  }
 });
-
-console.log(valid); //=> false
-console.log(value); //=> { name: { first: 42 } }
 ```
 
-The `errors` array will look like:
+## `mapAdapter(fn)`
 
-``` js
-[{
-  code: "is.type",
-  path: ["name", "first"],
-  message: "wrong type: expected string",
-  expectedType: "string",
-  value: 42,
-}]
+Thin alias for `new Validator(fn)`. A function passed to the `Validator`
+constructor already acts as a transform — whatever the function returns
+(if not `undefined`) replaces the value.
+
+```js
+const upper = mapAdapter((v) => v.toUpperCase());
+upper.validate("hi").value; // "HI"
 ```
 
-### `items(...fns)`
+## Errors
 
-The `items()` function is used to transform and validate all items in an array.
-Here's a transformation example that doubles numbers in an array and then
-repeats the digits:
+All errors subclass `ValidationError`:
 
-``` js
-const { schema, items, mapAdapter } = require("schema-fns");
-
-const MySchema = schema(
-  items(
-    mapAdapter(value => value * 2),
-    mapAdapter(value => String(value) + String(value)),
-    mapAdapter(Number)
-  ),
-);
-
-const { valid, value, errors } = MySchema.validate([ 1, 2, 3 ]);
-
-console.log(valid); //=> true
-console.log(value); //=> [ 22, 44, 66 ]);
+```
+ValidationError
+├── RequiredError
+├── MinLengthError
+├── MinimumStringLengthError
+├── MaximumStringLengthError
+├── MissingKeyError
+├── WrongTypeValidationError
+├── InvalidURLError
+├── InvalidEmailError
+├── InvalidISODateError
+├── MinimumNumberError
+├── MaximumNumberError
+├── FiniteNumberError
+├── NonIntegerError
+├── PositiveNumberError
+└── NonNegativeNumberError
 ```
 
-It can be used for validation as well:
+Every error has a `path` describing its location in the input, and may
+carry a `details` object with context (`value`, `minLength`, etc.).
 
-``` js
-const { schema, is, items } = require("schema-fns");
+## Migrating from 0.1.x
 
-const MySchema = schema(
-  items(is(Number)),
-);
+`1.0.0` is a breaking rewrite on top of a `Validator` class. No
+backwards-compat shims.
 
-const { valid, value, errors } = MySchema.validate([ 1, 2, "3", 4, "5" ]);
+| 0.1.x                   | 1.0.0                                              |
+| ----------------------- | -------------------------------------------------- |
+| `isType(T)` / `is(T)`   | `type(T)`                                          |
+| `as(T)` / `to(T)`       | `type.to(T)`                                       |
+| `isOneOf(...v)`         | `oneOf(...v)`                                      |
+| `isUrl()`               | `string.url()`                                     |
+| `length(min, max)`      | `string.minLength(min)` + `string.maxLength(max)`  |
+| `hasKeys(...keys)`      | `hasKey(key)` (one per call)                       |
+| `(value, update, error)` handler | `new Validator(fn)` / plain `fn` in `schema()` |
+| error objects with `code` | `ValidationError` subclass instances             |
 
-console.log(valid); //=> false
-console.log(value); //=> [ 1, 2, "3", 4, "5" ]
-```
+The handler shape changed. Instead of calling `update()` and `error()`,
+return the transformed value (or `undefined` to leave it alone) and
+throw `ValidationError` instances to fail.
 
-The `errors` array will look like:
+## Credits
 
-``` js
-[{
-  code: "is.type",
-  path: [2],
-  message: "wrong type: expected number",
-  expectedType: "number",
-  value: "3",
-}, {
-  code: "is.type",
-  path: [4],
-  message: "wrong type: expected number",
-  expectedType: "number",
-  value: "5",
-}]
-```
-
-
-## Custom input validation
-
-Writing custom validators is as simple as calling the `error()` function,
-passing a string error code and a context object with additional information
-useful for debugging or messaging to an end user.
-
-
-``` js
-const { schema, is, items } = require("schema-fns");
-
-const MySchema = schema(
-  notFoo(),
-);
-
-// fails validation if the value equals "foo", "FOO", etc
-function notFoo() {
-  return function (value, update, error) {
-    if (String(value).toLowerCase() === "foo") {
-      // first argument is a unique error code
-      // second argument is a context object
-      error("not.foo", {
-        message: `not foo expected, got ${value}`,
-        value,
-      });
-    }
-  };
-}
-
-console.log(MySchema.test("foo")); //=> false
-console.log(MySchema.test("fOO")); //=> false
-console.log(MySchema.test("FOo")); //=> false
-console.log(MySchema.test(42)); //=> true
-console.log(MySchema.test({})); //=> true
-```
-
-
-## Credit
-
-Inspired by [Joi](https://joi.dev/api/) and [superstruct](https://docs.superstructjs.org/).
-
-
+Inspired by [Joi](https://joi.dev/api/) and
+[superstruct](https://docs.superstructjs.org/).

--- a/README.md
+++ b/README.md
@@ -199,14 +199,14 @@ const evenNumber = new Validator((value) => {
 });
 ```
 
-## `mapAdapter(fn)`
+## Transforms
 
-Thin alias for `new Validator(fn)`. A function passed to the `Validator`
-constructor already acts as a transform — whatever the function returns (if not
-`undefined`) replaces the value.
+A `Validator`'s function can return a new value. Whatever it returns (if not
+`undefined`) replaces the input; returning `undefined` leaves the input
+unchanged.
 
 ```js
-const upper = mapAdapter((value) => value.toUpperCase());
+const upper = new Validator((value) => value.toUpperCase());
 upper.validate("hi").value; // "HI"
 ```
 
@@ -250,6 +250,7 @@ shims.
 | `length(min, max)`               | `string.minLength(min)` + `string.maxLength(max)` |
 | `hasKeys(...keys)`               | `hasKey(key)` (one per call)                      |
 | `(value, update, error)` handler | `new Validator(fn)` / plain `fn` in `schema()`    |
+| `mapAdapter(fn)`                 | `new Validator(fn)`                               |
 | error objects with `code`        | `ValidationError` subclass instances              |
 
 The handler shape changed. Instead of calling `update()` and `error()`, return

--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ number.positive();        // > 0, throws PositiveNumberError
 number.nonNegative();     // >= 0, throws NonNegativeNumberError
 ```
 
+`number.*` bound checks accept cleanly-coercible strings so form inputs work
+without a preceding `type.to(Number)`. `"5"` and `" 5 "` pass; `""`, `"abc"`,
+`"5abc"`, `NaN`, `Infinity`, `null`, `undefined`, booleans, arrays, and plain
+objects are rejected. Values pass through unchanged. Use `type.to(Number)` if
+you want the output transformed.
+
 ## Length
 
 ### `minLength(n)`

--- a/README.md
+++ b/README.md
@@ -172,11 +172,18 @@ number.positive();        // > 0, throws PositiveNumberError
 number.nonNegative();     // >= 0, throws NonNegativeNumberError
 ```
 
-`number.*` bound checks accept cleanly-coercible strings so form inputs work
-without a preceding `type.to(Number)`. `"5"` and `" 5 "` pass; `""`, `"abc"`,
-`"5abc"`, `NaN`, `Infinity`, `null`, `undefined`, booleans, arrays, and plain
-objects are rejected. Values pass through unchanged. Use `type.to(Number)` if
-you want the output transformed.
+`number.*` is strict: non-numbers (including numeric strings like `"5"`) and
+`NaN` are rejected. Coerce at the boundary with `type.to(Number)` when the input
+is a string:
+
+```js
+// For form inputs that arrive as strings:
+const Age = schema(type.to(Number), number.integer(), number.nonNegative());
+Age.validate("5").value; // 5
+```
+
+This keeps validators honest about what they accept and leaves coercion visible
+in the schema itself.
 
 ## Length
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ ESM only; Node 22+.
 
 ## Overview
 
-Build schemas by composing `Validator` instances. Every primitive
-(`type`, `required`, `string.url`, `number.min`, etc.) returns a
-`Validator`. `schema()`, `key()`, and `items()` compose validators into
-larger ones.
+Build schemas by composing `Validator` instances. Every primitive (`type`,
+`required`, `string.url`, `number.min`, etc.) returns a `Validator`. `schema()`,
+`key()`, and `items()` compose validators into larger ones.
 
 ```js
 import {
@@ -35,15 +34,15 @@ result.value; // { name: "Alice", age: 30 }
 
 ## `Validator`
 
-Every primitive returns a `Validator`. A schema is just a `Validator`
-built from other validators.
+Every primitive returns a `Validator`. A schema is just a `Validator` built from
+other validators.
 
 ### `.validate(value)` / `.validateAsync(value)`
 
-Returns a `ValidationResult`. On success, `{ valid: true, value }`. On
-failure, `{ valid: false, errors }`. `errors` is an array of
-`ValidationError` (or subclass) instances, each with a `path` describing
-where in the input the failure happened.
+Returns a `ValidationResult`. On success, `{ valid: true, value }`. On failure,
+`{ valid: false, errors }`. `errors` is an array of `ValidationError` (or
+subclass) instances, each with a `path` describing where in the input the
+failure happened.
 
 ### `.test(value)` / `.testAsync(value)`
 
@@ -51,13 +50,13 @@ Returns a boolean.
 
 ### `.assert(value)` / `.assertAsync(value)`
 
-Returns the successful `ValidationResult`, or throws a `ValidationError`
-whose `.errors` is the full error list.
+Returns the successful `ValidationResult`, or throws a `ValidationError` whose
+`.errors` is the full error list.
 
 ### `.message(stringOrFunction)`
 
-Replaces the default message on any error the validator produces.
-Chainable; returns `this`.
+Replaces the default message on any error the validator produces. Chainable;
+returns `this`.
 
 ```js
 const Age = number.integer().message("Age must be a whole number.");
@@ -75,43 +74,42 @@ const Min = minLength(3).message(
 
 ### `schema(...validators)`
 
-Runs each validator in order. Accumulates errors; returns the
-transformed `value` if all pass.
+Runs each validator in order. Accumulates errors; returns the transformed
+`value` if all pass.
 
 ### `key(name, ...validators)`
 
-Focuses on a property of an object. Errors are emitted with
-`path = [name, ...inner.path]`.
+Focuses on a property of an object. Errors are emitted with `path = [name,
+...inner.path]`.
 
 ### `items(...validators)`
 
-Validates every item in an array. Errors are emitted with
-`path = [index, ...inner.path]`. Fails if the value isn't an array.
+Validates every item in an array. Errors are emitted with `path = [index,
+...inner.path]`. Fails if the value isn't an array.
 
 ### `hasKey(name)`
 
-Requires a key to be present (with a non-`undefined` value). Supports
-string or symbol keys. Throws `MissingKeyError`.
+Requires a key to be present (with a non-`undefined` value). Supports string or
+symbol keys. Throws `MissingKeyError`.
 
 ## Presence
 
 ### `required(...validators)`
 
 Fails (`RequiredError`) if the value is missing. Missing means `null`,
-`undefined`, `NaN`, empty string, length-0 array/string, size-0
-Map/Set, or any value `isEmpty()` treats as empty. If present, runs the
-inner validators.
+`undefined`, `NaN`, empty string, length-0 array/string, size-0 Map/Set, or any
+value `isEmpty()` treats as empty. If present, runs the inner validators.
 
 ### `optional(...validators)`
 
-Passes without running inner validators if the value is `undefined`,
-`null`, or `""`. Otherwise runs them.
+Passes without running inner validators if the value is `undefined`, `null`, or
+`""`. Otherwise runs them.
 
 ### `isEmpty(value)`
 
-Primitives are never empty. Arrays/strings check `.length`. Maps/Sets
-check `.size`. Iterables check for any item. Plain objects check for
-any enumerable property.
+Primitives are never empty. Arrays/strings check `.length`. Maps/Sets check
+`.size`. Iterables check for any item. Plain objects check for any enumerable
+property.
 
 ## Types
 
@@ -122,8 +120,8 @@ Passes if the value matches `Type`. Accepts:
 - strict equality (for `null`/`undefined`)
 - `value instanceof Type` (for classes)
 - `typeof value === Type` (for strings like `"string"`)
-- `typeof value === Type.name.toLowerCase()` (for primitive
-  constructors like `String`, `Number`)
+- `typeof value === Type.name.toLowerCase()` (for primitive constructors like
+  `String`, `Number`)
 
 Throws `WrongTypeValidationError`.
 
@@ -133,10 +131,10 @@ Passes if `value instanceof` any of the given types.
 
 ### `type.to(Type)`
 
-Coerces the value to a target type. Built-in conversions for `Array`,
-`BigInt`, `Boolean`, `Date`, `Function`, `Map`, `Number`, `Object`,
-`Promise`, `RegExp`, `Set`, `String`, `Symbol`, `Uint8Array`. Unknown
-types are called as `Type(value)`.
+Coerces the value to a target type. Built-in conversions for `Array`, `BigInt`,
+`Boolean`, `Date`, `Function`, `Map`, `Number`, `Object`, `Promise`, `RegExp`,
+`Set`, `String`, `Symbol`, `Uint8Array`. Unknown types are called as
+`Type(value)`.
 
 ```js
 const parseAge = type.to(Number);
@@ -158,9 +156,9 @@ string.email();           // throws InvalidEmailError
 string.isoDate();         // throws InvalidISODateError (YYYY-MM-DD)
 ```
 
-`string.url()` accepts bare domains (`"example.com"`), rejects IPs and
-unlisted domains. `string.isoDate()` rejects format mismatches and
-invalid calendar dates (e.g. `2024-02-30`).
+`string.url()` accepts bare domains (`"example.com"`), rejects IPs and unlisted
+domains. `string.isoDate()` rejects format mismatches and invalid calendar dates
+(e.g. `2024-02-30`).
 
 ## Numbers
 
@@ -178,15 +176,15 @@ number.nonNegative();     // >= 0, throws NonNegativeNumberError
 
 ### `minLength(n)`
 
-Generic length check; works on any value with a numeric `.length`.
-Throws `MinLengthError`. Distinct from `string.minLength`, which also
-asserts string-specific behavior.
+Generic length check; works on any value with a numeric `.length`. Throws
+`MinLengthError`. Distinct from `string.minLength`, which also asserts
+string-specific behavior.
 
 ## Custom validators
 
 Subclass `Validator` or pass a function to its constructor. Throw a
-`ValidationError` (or subclass) to fail validation. Any other thrown
-value bubbles out of `.validate()`.
+`ValidationError` (or subclass) to fail validation. Any other thrown value
+bubbles out of `.validate()`.
 
 ```js
 import { Validator, ValidationError } from "schema-fns";
@@ -204,11 +202,11 @@ const evenNumber = new Validator((value) => {
 ## `mapAdapter(fn)`
 
 Thin alias for `new Validator(fn)`. A function passed to the `Validator`
-constructor already acts as a transform — whatever the function returns
-(if not `undefined`) replaces the value.
+constructor already acts as a transform — whatever the function returns (if not
+`undefined`) replaces the value.
 
 ```js
-const upper = mapAdapter((v) => v.toUpperCase());
+const upper = mapAdapter((value) => value.toUpperCase());
 upper.validate("hi").value; // "HI"
 ```
 
@@ -235,28 +233,28 @@ ValidationError
 └── NonNegativeNumberError
 ```
 
-Every error has a `path` describing its location in the input, and may
-carry a `details` object with context (`value`, `minLength`, etc.).
+Every error has a `path` describing its location in the input, and may carry a
+`details` object with context (`value`, `minLength`, etc.).
 
 ## Migrating from 0.1.x
 
-`1.0.0` is a breaking rewrite on top of a `Validator` class. No
-backwards-compat shims.
+`1.0.0` is a breaking rewrite on top of a `Validator` class. No backwards-compat
+shims.
 
-| 0.1.x                   | 1.0.0                                              |
-| ----------------------- | -------------------------------------------------- |
-| `isType(T)` / `is(T)`   | `type(T)`                                          |
-| `as(T)` / `to(T)`       | `type.to(T)`                                       |
-| `isOneOf(...v)`         | `oneOf(...v)`                                      |
-| `isUrl()`               | `string.url()`                                     |
-| `length(min, max)`      | `string.minLength(min)` + `string.maxLength(max)`  |
-| `hasKeys(...keys)`      | `hasKey(key)` (one per call)                       |
-| `(value, update, error)` handler | `new Validator(fn)` / plain `fn` in `schema()` |
-| error objects with `code` | `ValidationError` subclass instances             |
+| 0.1.x                            | 1.0.0                                             |
+| -------------------------------- | ------------------------------------------------- |
+| `isType(T)` / `is(T)`            | `type(T)`                                         |
+| `as(T)` / `to(T)`                | `type.to(T)`                                      |
+| `isOneOf(...v)`                  | `oneOf(...v)`                                     |
+| `isUrl()`                        | `string.url()`                                    |
+| `length(min, max)`               | `string.minLength(min)` + `string.maxLength(max)` |
+| `hasKeys(...keys)`               | `hasKey(key)` (one per call)                      |
+| `(value, update, error)` handler | `new Validator(fn)` / plain `fn` in `schema()`    |
+| error objects with `code`        | `ValidationError` subclass instances              |
 
-The handler shape changed. Instead of calling `update()` and `error()`,
-return the transformed value (or `undefined` to leave it alone) and
-throw `ValidationError` instances to fail.
+The handler shape changed. Instead of calling `update()` and `error()`, return
+the transformed value (or `undefined` to leave it alone) and throw
+`ValidationError` instances to fail.
 
 ## Credits
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "schema-fns",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "schema-fns",
-      "version": "0.1.5",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "is": "^3.3.0",
-        "parse-domain": "^3.0.3",
-        "url-parse-lax": "^4.0.0"
+        "parse-domain": "^3.0.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -24,15 +22,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/is/-/is-3.3.2.tgz",
-      "integrity": "sha512-a2xr4E3s1PjDS8ORcGgXpWx6V+liNs+O3JRD2mb9aeugD7rtkkZ0zgLdYgw0tWsKhsdiezGYptSiMlVazCBTuQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/is-ip": {
@@ -81,15 +70,6 @@
         "parse-domain-update": "bin/update.js"
       }
     },
-    "node_modules/prepend-http": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-3.0.1.tgz",
-      "integrity": "sha512-BLxfZh+m6UiAiCPZFJ4+vYoL7NrRs5XgCTRrjseATAggXhdZKKxn+JUNmuVYWY23bDHgaEHodxw8mnmtVEDtHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -104,18 +84,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
-    },
-    "node_modules/url-parse-lax": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-4.0.0.tgz",
-      "integrity": "sha512-CazaJJZUPr1EWmHjcntgS1F1q6YOpQROD6Z+aTb9obxgOFsRydnqYkRCh5xDJ3LhqTID46JrWaT7PsF7Oms0PA==",
-      "license": "MIT",
-      "dependencies": {
-        "prepend-http": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "schema-fns",
   "description": "Composable schema functions for input transformation and validation",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "type": "module",
   "main": "schema.js",
   "scripts": {
@@ -27,9 +27,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "is": "^3.3.0",
-    "parse-domain": "^3.0.3",
-    "url-parse-lax": "^4.0.0"
+    "parse-domain": "^3.0.3"
   },
   "volta": {
     "node": "22.22.2"

--- a/schema.js
+++ b/schema.js
@@ -1,344 +1,622 @@
-import is from "is";
-import urlParseLax from "url-parse-lax";
+import assert from "node:assert";
 import { parseDomain } from "parse-domain";
 
-export function schema(...fns) {
-  // ensure all args are functions
-  for (const [index, fn] of Object.entries(fns)) {
-    if (!is.fn(fn)) {
-      const msg = `schema(): value with index ${index} is not a function`;
-      const error = new TypeError(msg);
-      error.value = fn;
-      throw error;
-    }
-  }
-  function handler(value, update, error) {
-    const { value: output, errors } = validate(value);
-    for (const e of errors) {
-      const { code, ...context } = e;
-      error(code, context);
-    }
-    update(output);
-  }
 
-  handler.validate = validate;
-  handler.test = test;
-  handler.assert = assert;
-  handler.validateAsync = validateAsync;
-  handler.testAsync = testAsync;
-  handler.assertAsync = assertAsync;
+export class ValidationError extends Error {
+  path = [];
 
-  function validate(input) {
-    return validationPipeline(...fns)(input);
-  }
-
-  async function validateAsync(input) {
-    return await validationPipelineAsync(...fns)(input);
-  }
-
-  function test(input) {
-    const { valid } = validate(input);
-    return valid;
-  }
-
-  async function testAsync(input) {
-    const { valid } = await validateAsync(input);
-    return valid;
-  }
-
-  function assert(input) {
-    const { valid, value, errors } = validate(input);
-    if (!valid) {
-      throw createValidationError(errors);
+  constructor(messageOrOptions, extrasArg = undefined) {
+    if (typeof messageOrOptions === "string") {
+      const message = messageOrOptions;
+      super(message);
+      if (extrasArg) Object.assign(this, extrasArg);
     } else {
-      return {
-        valid,
-        value,
-      };
+      const { message, ...extras } = messageOrOptions;
+      super(message);
+      Object.assign(this, extras);
     }
   }
-
-  async function assertAsync(input) {
-    const { valid, value, errors } = await validateAsync(input);
-    if (!valid) {
-      throw createValidationError(errors);
-    } else {
-      return {
-        valid,
-        value,
-      };
-    }
-  }
-
-  function createValidationError(errors) {
-    const message = [
-      `Schema validation failed: ${errors.length} errors found`,
-      ...errors.map(formatError),
-    ].join("\n");
-    const error = new ValidationError(message);
-    error.details = [...errors];
-    return error;
-  }
-
-  return handler;
 }
 
-class ValidationError extends Error {}
+export class RequiredError extends ValidationError {}
 
-function formatError(error) {
-  const { code, path, message, value } = error;
-  return `[${code}] ${path.join(".")}: ${message}, received: ${value}`;
+export class MinLengthError extends ValidationError {
+  constructor({ message, minLength, ...extras }) {
+    super({
+      message: message ?? `Value must be at least ${minLength} in length`,
+      minLength,
+      ...extras,
+    });
+  }
 }
 
-export function key(name, ...fns) {
-  const keySchema = schema(...fns);
+export class MinimumStringLengthError extends ValidationError {}
+export class MaximumStringLengthError extends ValidationError {}
+export class MissingKeyError extends ValidationError {}
+export class WrongTypeValidationError extends ValidationError {}
+export class InvalidURLError extends ValidationError {}
+export class InvalidEmailError extends ValidationError {}
+export class InvalidISODateError extends ValidationError {}
+export class MinimumNumberError extends ValidationError {}
+export class MaximumNumberError extends ValidationError {}
+export class FiniteNumberError extends ValidationError {}
+export class NonIntegerError extends ValidationError {}
+export class PositiveNumberError extends ValidationError {}
+export class NonNegativeNumberError extends ValidationError {}
 
-  return function (value, update, error) {
+
+export class ValidationResult {
+  static ok(value) {
+    return new ValidationResult({ valid: true, value });
+  }
+
+  static error(errors) {
+    return new ValidationResult({ valid: false, errors });
+  }
+
+  constructor({ valid, value, errors }) {
+    assert(
+      typeof valid === "boolean",
+      new TypeError("ValidationResult: options.valid must be a boolean"),
+    );
+
+    if (valid) {
+      this.valid = true;
+      this.value = value;
+    } else {
+      this.valid = false;
+      this.errors = errors;
+    }
+  }
+}
+
+
+export class Validator {
+  #validateFunction = () => {};
+  #messageFunction = null;
+
+  constructor(validateFunction) {
+    assert(
+      typeof validateFunction === "function",
+      new TypeError(
+        "new Validator(validateFunction): validateFunction must be a function",
+      ),
+    );
+    this.#validateFunction = validateFunction;
+  }
+
+  message(stringOrFunction) {
+    switch (typeof stringOrFunction) {
+      case "string": {
+        const s = stringOrFunction;
+        this.#messageFunction = () => s;
+        return this;
+      }
+      case "function": {
+        this.#messageFunction = stringOrFunction;
+        return this;
+      }
+      default:
+        throw new TypeError(
+          "Validator.message(stringOrFunction): stringOrFunction must be a string or function",
+        );
+    }
+  }
+
+  validate(value) {
+    try {
+      const returnValue = this.#validateFunction(value);
+      if (typeof returnValue !== "undefined") value = returnValue;
+      return ValidationResult.ok(value);
+    } catch (errors) {
+      return this.#handleErrors(errors);
+    }
+  }
+
+  async validateAsync(value) {
+    try {
+      const returnValue = await this.#validateFunction(value);
+      if (typeof returnValue !== "undefined") value = returnValue;
+      return ValidationResult.ok(value);
+    } catch (errors) {
+      return this.#handleErrors(errors);
+    }
+  }
+
+  #handleErrors(errors) {
+    errors = ensureArray(errors);
+    const allValidationErrors = errors.every(
+      (error) => error instanceof ValidationError,
+    );
+
+    if (allValidationErrors) {
+      if (this.#messageFunction) {
+        for (const error of errors) {
+          error.message = this.#messageFunction(error);
+        }
+      }
+      return ValidationResult.error(errors);
+    } else {
+      const nonValidationErrors = errors.filter(
+        (error) => !(error instanceof ValidationError),
+      );
+      throw nonValidationErrors;
+    }
+  }
+
+  test(value) {
+    return this.validate(value).valid;
+  }
+
+  async testAsync(value) {
+    return (await this.validateAsync(value)).valid;
+  }
+
+  assert(value) {
+    const result = this.validate(value);
+    if (!result.valid) {
+      throw new ValidationError({
+        message: "Validation failed",
+        errors: result.errors,
+      });
+    }
+    return result;
+  }
+
+  async assertAsync(value) {
+    const result = await this.validateAsync(value);
+    if (!result.valid) {
+      throw new ValidationError({
+        message: "Validation failed",
+        errors: result.errors,
+      });
+    }
+    return result;
+  }
+}
+
+
+export function schema(...functionsOrValidators) {
+  const validators = functionsOrValidators.map((fn, index) => {
+    if (fn instanceof Validator) return fn;
+    if (typeof fn === "function") return new Validator(fn);
+    throw Object.assign(
+      new TypeError(
+        `schema(): argument at index ${index} is not a function or Validator`,
+      ),
+      { index, argument: fn },
+    );
+  });
+
+  return new Validator((value) => {
+    const errors = [];
+    for (const validator of validators) {
+      const result = validator.validate(value);
+      if (result.valid) {
+        value = result.value;
+      } else {
+        errors.push(...result.errors);
+      }
+    }
+    if (errors.length > 0) throw errors;
+    return value;
+  });
+}
+
+export function key(name, ...functionsOrValidators) {
+  const KeySchema = schema(...functionsOrValidators);
+
+  return new Validator((value) => {
     const input = value[name];
-    keySchema(input, keyUpdate, keyError);
+    const result = KeySchema.validate(input);
 
-    function keyUpdate(newKeyValue) {
-      const newValue = {
-        ...value,
-        [name]: newKeyValue,
-      };
-      update(newValue);
+    if (result.valid) {
+      return { ...value, [name]: result.value };
     }
+    throw result.errors.map((error) => {
+      error.path = [name].concat(error.path ?? []);
+      return error;
+    });
+  });
+}
 
-    function keyError(code, context) {
-      // runs depth first, so we need to prepend the key name
-      error(code, {
-        ...context,
-        path: [name].concat(context.path || []),
+export function items(...functionsOrValidators) {
+  const ItemSchema = schema(...functionsOrValidators);
+
+  return new Validator((value) => {
+    if (!Array.isArray(value)) {
+      throw new ValidationError({
+        message: "value must be an array",
+        details: { value, valueType: typeof value },
       });
     }
-  };
-}
 
-// validate an array of items
-export function items(...fns) {
-  const itemSchema = schema(...fns);
+    const items = value;
+    const errors = [];
 
-  return function (value, update, error) {
-    let items = value;
-    let index = 0;
-
-    while (index < items.length) {
-      const item = items[index];
-      itemSchema(item, itemUpdate, itemError);
-      index++;
-
-      function itemUpdate(newItemValue) {
-        const newValue = [...items];
-        newValue[index] = newItemValue;
-        update(newValue);
-        items = newValue;
-      }
-
-      function itemError(code, context) {
-        // runs depth first, so we need to prepend the key name
-        error(code, {
-          ...context,
-          path: [index].concat(context.path || []),
-        });
+    for (let index = 0; index < items.length; index++) {
+      const result = ItemSchema.validate(items[index]);
+      if (result.valid) {
+        items[index] = result.value;
+      } else {
+        for (const error of result.errors) {
+          error.path = [index].concat(error.path ?? []);
+          errors.push(error);
+        }
       }
     }
-  };
+
+    if (errors.length > 0) throw errors;
+    return items;
+  });
 }
 
-export function hasKeys(...keys) {
-  // TODO: assert keys are all strings
-  return function (value, update, error) {
-    const missingKeys = keys.filter(key => !(key in value));
-    for (const key of missingKeys) {
-      error("key.missing", {
-        message: `expected key "${key}" missing`,
-        key: key,
-        value: value,
-      });
-    }
-  };
-}
+export function hasKey(key) {
+  const isStringOrSymbol =
+    typeof key === "string" || typeof key === "symbol";
 
-function validationPipeline(...functions) {
-  return function execValidationPipeline(input, update, error) {
-    const errors = [];
-    let value = input;
-
-    for (const fn of functions) {
-      fn(value, update, error);
-    }
-
-    const valid = !Boolean(errors.length);
-    return { value, valid, errors };
-
-    function update(newValue) {
-      value = newValue;
-    }
-
-    function error(code, context) {
-      const e = {
-        code,
-        path: [],
-        ...context,
-      };
-      errors.push(e);
-    }
+  if (!isStringOrSymbol) {
+    throw Object.assign(
+      new TypeError(
+        `hasKey(): key must be a string or symbol. Got: ${typeof key}`,
+      ),
+      { value: key },
+    );
   }
-}
 
-function validationPipelineAsync(...functions) {
-  return async function execValidationPipelineAsync(input, update, error) {
-    const errors = [];
-    let value = input;
+  return new Validator((value) => {
+    const defined =
+      value !== null &&
+      value !== undefined &&
+      value[key] !== undefined;
 
-    for (const fn of functions) {
-      await fn(value, update, error);
-    }
-
-    const valid = !Boolean(errors.length);
-    return { value, valid, errors };
-
-    function update(newValue) {
-      value = newValue;
-    }
-
-    function error(code, context) {
-      const e = {
-        code,
-        path: [],
-        ...context,
-      };
-      errors.push(e);
-    }
-  }
-}
-
-export function mapAdapter(mapFn) {
-  return function (value, update) {
-    const returnValue = mapFn(value);
-    if (typeof returnValue !== "undefined") {
-      update(returnValue);
-    }
-  };
-}
-
-export function isType(type) {
-  const types = new Map();
-  types.set("undefined", { expected: "undefined", test: is.undefined });
-  types.set(undefined,   { expected: "undefined", test: is.undefined });
-  types.set("null",      { expected: "null",      test: is.null });
-  types.set(null,        { expected: "null",      test: is.null });
-  types.set(Object,      { expected: "object",    test: is.object });
-  types.set("object",    { expected: "object",    test: is.object });
-  types.set(Array,       { expected: "array",     test: is.array });
-  types.set("array",     { expected: "array",     test: is.array });
-  types.set(Boolean,     { expected: "boolean",   test: is.boolean });
-  types.set("boolean",   { expected: "boolean",   test: is.boolean });
-  types.set(Number,      { expected: "number",    test: is.number });
-  types.set("number",    { expected: "number",    test: is.number });
-  types.set(BigInt,      { expected: "bigint",    test: is.bigint });
-  types.set("bigint",    { expected: "bigint",    test: is.bigint });
-  types.set(String,      { expected: "string",    test: is.string });
-  types.set("string",    { expected: "string",    test: is.string });
-  types.set(Symbol,      { expected: "symbol",    test: is.symbol });
-  types.set("symbol",    { expected: "symbol",    test: is.symbol });
-  types.set(Function,    { expected: "function",  test: is.function });
-  types.set("function",  { expected: "function",  test: is.function });
-
-  return function (value, update, error) {
-    const { expected, test } = types.get(type);
-    if (!test(value)) {
-      error("is.type", {
-        message: `wrong type: expected ${expected}`,
-        expectedType: expected,
+    if (!defined) {
+      throw new MissingKeyError({
+        message: `Expected key "${String(key)}" is missing`,
+        key,
         value,
       });
     }
-  };
+  });
 }
 
-export function as(type) {
-  const types = new Map();
-  types.set(Boolean,   function (value) { return Boolean(value); });
-  types.set("boolean", function (value) { return Boolean(value); });
-  types.set(Number,    function (value) { return Number(value); });
-  types.set("number",  function (value) { return Number(value); });
-  types.set(BigInt,    function (value) { return BigInt(value); });
-  types.set("bigint",  function (value) { return BigInt(value); });
-  types.set(String,    function (value) { return String(value); });
-  types.set("string",  function (value) { return String(value); });
 
-  return function (value, update) {
-    const fn = types.get(type);
-    const newValue = fn(value);
-    update(newValue);
-  };
-}
-
-// FIXME: add tests
-export function isOneOf(...values) {
-  return function (value, update, error) {
-    if (!values.includes(value)) {
-      error("is.oneof", {
-        message: `expected one of [${values.join(", ")}], got ${value}`,
-        value: value,
+export function required(...functionsOrValidators) {
+  const Inner = schema(...functionsOrValidators);
+  return new Validator((value) => {
+    if (
+      value === null ||
+      value === undefined ||
+      Number.isNaN(value) ||
+      value?.valueOf?.() === "" ||
+      value?.length === 0 ||
+      value?.size === 0 ||
+      isEmpty(value)
+    ) {
+      throw new RequiredError({
+        message: "Value is required",
+        details: { value },
       });
     }
-  };
+    const result = Inner.validate(value);
+    if (result.valid) return result.value;
+    throw result.errors;
+  });
 }
 
-// FIXME: add tests
-export function isUrl() {
-  return function (value, update, error) {
-    if (value && value.length) {
-      const parsedUrl = urlParseLax(value);
+export function optional(...functionsOrValidators) {
+  const Inner = schema(...functionsOrValidators);
+  const emptyValues = [undefined, null, ""];
+
+  return new Validator((value) => {
+    if (emptyValues.includes(value)) return;
+    const result = Inner.validate(value);
+    if (result.valid) return result.value;
+    throw result.errors;
+  });
+}
+
+
+export function type(Type) {
+  return new Validator((value) => {
+    if (
+      value === Type ||
+      (typeof Type === "function" && value instanceof Type) ||
+      typeof value === Type ||
+      typeof value === Type?.name?.toLowerCase()
+    ) {
+      return;
+    }
+    const typeName = Type?.name ?? Type;
+    throw new WrongTypeValidationError({
+      message: `wrong type: expected ${typeName}, got ${typeof value}`,
+      details: { expectedType: Type, value },
+    });
+  });
+}
+
+type.oneOf = function typeOneOf(...allowedTypes) {
+  return new Validator((value) => {
+    if (!allowedTypes.some((T) => value instanceof T)) {
+      const typeNames = allowedTypes.map((T) => T.name ?? T);
+      throw new ValidationError({
+        message: `Value must be one of: ${serialComma(typeNames, "or")}`,
+        details: { value, allowedTypes },
+      });
+    }
+  });
+};
+
+type.to = function toType(Type) {
+  const conversions = new Map();
+  conversions.set(Array, (v) => Array.from(v));
+  conversions.set(BigInt, (v) => BigInt(v));
+  conversions.set(Boolean, (v) => Boolean(v));
+  conversions.set(Date, (v) => new Date(v));
+  conversions.set(Function, (v) => Function(v));
+  conversions.set(Map, (v) => new Map(v));
+  conversions.set(Number, (v) => Number(v));
+  conversions.set(Object, (v) => Object(v));
+  conversions.set(Promise, (v) => Promise.resolve(v));
+  conversions.set(RegExp, (v) => new RegExp(v));
+  conversions.set(Set, (v) => new Set(v));
+  conversions.set(String, (v) => String(v));
+  conversions.set(Symbol, (v) => Symbol.for(v));
+  conversions.set(Uint8Array, (v) => new Uint8Array(v));
+
+  const convert = conversions.get(Type) ?? Type;
+
+  if (typeof convert !== "function") {
+    const typeName = Type?.name ?? Type;
+    throw new TypeError(`type.to(): unsupported type: ${typeName}`);
+  }
+
+  return new Validator((value) => convert(value));
+};
+
+export function oneOf(...values) {
+  return new Validator((value) => {
+    if (!values.includes(value)) {
+      throw new ValidationError({
+        message: `expected one of [${values.join(", ")}], got ${value}`,
+        details: { value, expectedValues: values },
+      });
+    }
+    return value;
+  });
+}
+
+
+export function minLength(minLen) {
+  return new Validator((value) => {
+    if (typeof value?.length !== "number") {
+      throw new MinLengthError({
+        message: "Value must have a numeric length property",
+        details: { value, minLength: minLen },
+      });
+    }
+    if (value.length < minLen) {
+      throw new MinLengthError({
+        message: `Length of value must be at least ${minLen}`,
+        details: { value, minLength: minLen },
+      });
+    }
+  });
+}
+
+
+export function string() {
+  return type(String);
+}
+
+string.minLength = function stringMinLength(minLen) {
+  return new Validator((value) => {
+    if (value.length < minLen) {
+      throw new MinimumStringLengthError({
+        message: `String must be at least ${minLen} characters long`,
+        details: { value, minLength: minLen },
+      });
+    }
+  });
+};
+
+string.maxLength = function stringMaxLength(maxLen) {
+  return new Validator((value) => {
+    if (value.length > maxLen) {
+      throw new MaximumStringLengthError({
+        message: `String must be no longer than ${maxLen} characters`,
+        details: { value, maxLength: maxLen },
+      });
+    }
+  });
+};
+
+string.url = function stringURL() {
+  return new Validator((value) => {
+    try {
+      const parsedUrl = new URL(prependHttp(value));
       const parsedDomain = parseDomain(parsedUrl.hostname);
 
       const domainValid =
         Boolean(parsedDomain.domain) &&
-        Boolean(parsedDomain.topLevelDomains.length) &&
+        Boolean(parsedDomain.topLevelDomains?.length) &&
         parsedDomain.type === "LISTED";
-      console.log(domainValid, parsedDomain);
+
       if (!domainValid) {
-        error("type.url", {
-          message: "There's something wrong with this URL.",
+        throw new InvalidURLError({
+          message: "This doesn't look like a URL",
+          details: { value, parsedUrl, parsedDomain },
         });
       }
-    }
-  };
-}
-
-// FIXME: add tests
-export function length(min = 0, max = Infinity) {
-  return function (value, update, error) {
-    if (value.length < min) {
-      const message = (min === 0) ?
-        `value cannot be empty` :
-        `value must be at least ${min} in length`;
-      error("length.min", {
-        message,
+    } catch (error) {
+      if (error instanceof InvalidURLError) throw error;
+      throw new InvalidURLError({
+        message: "This doesn't look like a URL",
+        details: { value, error },
       });
     }
+  });
+};
 
-    if (value.length > max) {
-      error("length.max", {
-        message: `value cannot exceed ${max} in length`,
+string.email = function stringEmail() {
+  return new Validator((value) => {
+    const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (typeof value !== "string" || !pattern.test(value)) {
+      throw new InvalidEmailError({
+        message: "Value must be a valid email address",
+        details: { value },
       });
     }
-  };
-}
+  });
+};
 
-// FIXME: add tests
-export function required() {
-  return function (value, update, error) {
-    if (!Boolean(value)) {
-      error("required", {
-        message: `value is required`,
-        value,
+string.isoDate = function stringIsoDate() {
+  return new Validator((value) => {
+    const pattern = /^\d{4}-\d{2}-\d{2}$/;
+    if (typeof value !== "string" || !pattern.test(value)) {
+      throw new InvalidISODateError({
+        message: "Value must be in ISO date format (YYYY-MM-DD)",
+        details: { value },
       });
     }
-  };
+    const date = new Date(value);
+    const roundTrip = Number.isNaN(date.getTime())
+      ? null
+      : date.toISOString().slice(0, 10);
+    if (roundTrip !== value) {
+      throw new InvalidISODateError({
+        message: "ISO date is invalid",
+        details: { value },
+      });
+    }
+  });
+};
+
+
+export function number() {
+  return type(Number);
 }
 
-export { isType as is, as as to };
+number.min = function numberMin(min) {
+  return new Validator((value) => {
+    if (value < min) {
+      throw new MinimumNumberError({
+        message: `Value must be at least ${min}`,
+        details: { value, min },
+      });
+    }
+  });
+};
+
+number.max = function numberMax(max) {
+  return new Validator((value) => {
+    if (value > max) {
+      throw new MaximumNumberError({
+        message: `Value must be no larger than ${max}`,
+        details: { value, max },
+      });
+    }
+  });
+};
+
+number.finite = function numberFinite() {
+  return new Validator((value) => {
+    if (!Number.isFinite(value)) {
+      throw new FiniteNumberError({
+        message: "Value must be a finite number",
+        details: { value },
+      });
+    }
+  });
+};
+
+number.integer = function numberInteger() {
+  return new Validator((value) => {
+    if (!Number.isInteger(value)) {
+      throw new NonIntegerError({
+        message: "Value must be an integer",
+        details: { value },
+      });
+    }
+  });
+};
+
+number.positive = function numberPositive() {
+  return new Validator((value) => {
+    if (typeof value !== "number" || value <= 0) {
+      throw new PositiveNumberError({
+        message: "Value must be a positive number",
+        details: { value },
+      });
+    }
+  });
+};
+
+number.nonNegative = function numberNonNegative() {
+  return new Validator((value) => {
+    if (typeof value !== "number" || value < 0) {
+      throw new NonNegativeNumberError({
+        message: "Value must be a non-negative number",
+        details: { value },
+      });
+    }
+  });
+};
+
+
+export function isEmpty(value) {
+  const EMPTY = true;
+  const NOT_EMPTY = false;
+
+  if (isPrimitive(value)) return NOT_EMPTY;
+  if (typeof value.length === "number") {
+    return value.length === 0 ? EMPTY : NOT_EMPTY;
+  }
+  if (typeof value.size === "number") {
+    return value.size === 0 ? EMPTY : NOT_EMPTY;
+  }
+
+  try {
+    for (const _ of value) return NOT_EMPTY;
+    return EMPTY;
+  } catch (_) {
+    // not iterable
+  }
+
+  try {
+    for (const _ of Object.entries(value)) return NOT_EMPTY;
+    return EMPTY;
+  } catch (_) {
+    // not enumerable
+  }
+
+  return NOT_EMPTY;
+}
+
+
+export const mapAdapter = (fn) => new Validator(fn);
+
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value : [value];
+}
+
+function isPrimitive(value) {
+  return (
+    value === null ||
+    (typeof value !== "object" && typeof value !== "function")
+  );
+}
+
+function prependHttp(value) {
+  if (typeof value !== "string") return value;
+  if (/^https?:\/\//i.test(value)) return value;
+  return "http://" + value;
+}
+
+function serialComma(items, conjunction = "and") {
+  if (items.length === 0) return "";
+  if (items.length === 1) return String(items[0]);
+  if (items.length === 2) return `${items[0]} ${conjunction} ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, ${conjunction} ${items.at(-1)}`;
+}

--- a/schema.js
+++ b/schema.js
@@ -627,13 +627,14 @@ export function number() {
 
 number.min = function numberMin(min) {
   return new Validator((value) => {
-    if (typeof value !== "number" || Number.isNaN(value)) {
+    const num = coerceFiniteNumber(value);
+    if (num === null) {
       throw new MinimumNumberError({
-        message: `Value must be a number to check min`,
+        message: "Value must be a number",
         details: { value, valueType: typeof value, min },
       });
     }
-    if (value < min) {
+    if (num < min) {
       throw new MinimumNumberError({
         message: `Value must be at least ${min}`,
         details: { value, min },
@@ -644,13 +645,14 @@ number.min = function numberMin(min) {
 
 number.max = function numberMax(max) {
   return new Validator((value) => {
-    if (typeof value !== "number" || Number.isNaN(value)) {
+    const num = coerceFiniteNumber(value);
+    if (num === null) {
       throw new MaximumNumberError({
-        message: `Value must be a number to check max`,
+        message: "Value must be a number",
         details: { value, valueType: typeof value, max },
       });
     }
-    if (value > max) {
+    if (num > max) {
       throw new MaximumNumberError({
         message: `Value must be no larger than ${max}`,
         details: { value, max },
@@ -661,7 +663,7 @@ number.max = function numberMax(max) {
 
 number.finite = function numberFinite() {
   return new Validator((value) => {
-    if (!Number.isFinite(value)) {
+    if (coerceFiniteNumber(value) === null) {
       throw new FiniteNumberError({
         message: "Value must be a finite number",
         details: { value },
@@ -672,7 +674,8 @@ number.finite = function numberFinite() {
 
 number.integer = function numberInteger() {
   return new Validator((value) => {
-    if (!Number.isInteger(value)) {
+    const num = coerceFiniteNumber(value);
+    if (num === null || !Number.isInteger(num)) {
       throw new NonIntegerError({
         message: "Value must be an integer",
         details: { value },
@@ -683,7 +686,8 @@ number.integer = function numberInteger() {
 
 number.positive = function numberPositive() {
   return new Validator((value) => {
-    if (typeof value !== "number" || value <= 0) {
+    const num = coerceFiniteNumber(value);
+    if (num === null || num <= 0) {
       throw new PositiveNumberError({
         message: "Value must be a positive number",
         details: { value },
@@ -694,7 +698,8 @@ number.positive = function numberPositive() {
 
 number.nonNegative = function numberNonNegative() {
   return new Validator((value) => {
-    if (typeof value !== "number" || value < 0) {
+    const num = coerceFiniteNumber(value);
+    if (num === null || num < 0) {
       throw new NonNegativeNumberError({
         message: "Value must be a non-negative number",
         details: { value },
@@ -702,6 +707,19 @@ number.nonNegative = function numberNonNegative() {
     }
   });
 };
+
+function coerceFiniteNumber(value) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return null;
+    const num = Number(trimmed);
+    return Number.isFinite(num) ? num : null;
+  }
+  return null;
+}
 
 
 export function isEmpty(value) {

--- a/schema.js
+++ b/schema.js
@@ -4,7 +4,7 @@ import { parseDomain } from "parse-domain";
 
 export class ValidationError extends Error {
   path = [];
-
+  
   constructor(messageOrOptions, extrasArg = undefined) {
     if (typeof messageOrOptions === "string") {
       const message = messageOrOptions;
@@ -49,17 +49,17 @@ export class ValidationResult {
   static ok(value) {
     return new ValidationResult({ valid: true, value });
   }
-
+  
   static error(errors) {
     return new ValidationResult({ valid: false, errors });
   }
-
+  
   constructor({ valid, value, errors }) {
     assert(
       typeof valid === "boolean",
       new TypeError("ValidationResult: options.valid must be a boolean"),
     );
-
+    
     if (valid) {
       this.valid = true;
       this.value = value;
@@ -73,23 +73,34 @@ export class ValidationResult {
 
 export class Validator {
   #validateFunction = () => {};
+  #validateAsyncFunction = null;
   #messageFunction = null;
-
-  constructor(validateFunction) {
+  
+  constructor(validateFunction, validateAsyncFunction = null) {
     assert(
       typeof validateFunction === "function",
       new TypeError(
         "new Validator(validateFunction): validateFunction must be a function",
       ),
     );
+    if (validateAsyncFunction !== null) {
+      assert(
+        typeof validateAsyncFunction === "function",
+        new TypeError(
+          "new Validator(_, validateAsyncFunction): " +
+            "validateAsyncFunction must be a function",
+        ),
+      );
+    }
     this.#validateFunction = validateFunction;
+    this.#validateAsyncFunction = validateAsyncFunction;
   }
-
+  
   message(stringOrFunction) {
     switch (typeof stringOrFunction) {
       case "string": {
-        const s = stringOrFunction;
-        this.#messageFunction = () => s;
+        const text = stringOrFunction;
+        this.#messageFunction = () => text;
         return this;
       }
       case "function": {
@@ -98,60 +109,67 @@ export class Validator {
       }
       default:
         throw new TypeError(
-          "Validator.message(stringOrFunction): stringOrFunction must be a string or function",
+          "Validator.message(stringOrFunction): " +
+            "stringOrFunction must be a string or function",
         );
     }
   }
-
+  
   validate(value) {
     try {
       const returnValue = this.#validateFunction(value);
+      if (isThenable(returnValue)) {
+        returnValue.catch(() => {});
+        throw new TypeError(
+          "Validator.validate() received a thenable return value. " +
+            "Use validateAsync() for async validators.",
+        );
+      }
       if (typeof returnValue !== "undefined") value = returnValue;
       return ValidationResult.ok(value);
     } catch (errors) {
       return this.#handleErrors(errors);
     }
   }
-
+  
   async validateAsync(value) {
+    const fn = this.#validateAsyncFunction ?? this.#validateFunction;
     try {
-      const returnValue = await this.#validateFunction(value);
+      const returnValue = await fn(value);
       if (typeof returnValue !== "undefined") value = returnValue;
       return ValidationResult.ok(value);
     } catch (errors) {
       return this.#handleErrors(errors);
     }
   }
-
+  
   #handleErrors(errors) {
-    errors = ensureArray(errors);
-    const allValidationErrors = errors.every(
+    const errorList = ensureArray(errors);
+    const allValidationErrors = errorList.every(
       (error) => error instanceof ValidationError,
     );
-
+    
     if (allValidationErrors) {
       if (this.#messageFunction) {
-        for (const error of errors) {
+        for (const error of errorList) {
           error.message = this.#messageFunction(error);
         }
       }
-      return ValidationResult.error(errors);
-    } else {
-      const nonValidationErrors = errors.filter(
-        (error) => !(error instanceof ValidationError),
-      );
-      throw nonValidationErrors;
+      return ValidationResult.error(errorList);
     }
+    
+    if (errorList.length === 1) throw errorList[0];
+    throw new AggregateError(errorList, "Validator received mixed errors");
   }
-
+  
   test(value) {
     return this.validate(value).valid;
   }
-
+  
   async testAsync(value) {
     return (await this.validateAsync(value)).valid;
   }
-
+  
   assert(value) {
     const result = this.validate(value);
     if (!result.valid) {
@@ -162,7 +180,7 @@ export class Validator {
     }
     return result;
   }
-
+  
   async assertAsync(value) {
     const result = await this.validateAsync(value);
     if (!result.valid) {
@@ -187,8 +205,8 @@ export function schema(...functionsOrValidators) {
       { index, argument: fn },
     );
   });
-
-  return new Validator((value) => {
+  
+  function sync(value) {
     const errors = [];
     for (const validator of validators) {
       const result = validator.validate(value);
@@ -200,61 +218,124 @@ export function schema(...functionsOrValidators) {
     }
     if (errors.length > 0) throw errors;
     return value;
-  });
+  }
+  
+  async function async(value) {
+    const errors = [];
+    for (const validator of validators) {
+      const result = await validator.validateAsync(value);
+      if (result.valid) {
+        value = result.value;
+      } else {
+        errors.push(...result.errors);
+      }
+    }
+    if (errors.length > 0) throw errors;
+    return value;
+  }
+  
+  return new Validator(sync, async);
 }
 
 export function key(name, ...functionsOrValidators) {
   const KeySchema = schema(...functionsOrValidators);
-
-  return new Validator((value) => {
-    const input = value[name];
-    const result = KeySchema.validate(input);
-
-    if (result.valid) {
-      return { ...value, [name]: result.value };
-    }
-    throw result.errors.map((error) => {
-      error.path = [name].concat(error.path ?? []);
-      return error;
-    });
-  });
+  
+  function sync(value) {
+    requireObjectLike(value, name);
+    const result = KeySchema.validate(value[name]);
+    return handleKeyResult(value, name, result);
+  }
+  
+  async function async(value) {
+    requireObjectLike(value, name);
+    const result = await KeySchema.validateAsync(value[name]);
+    return handleKeyResult(value, name, result);
+  }
+  
+  return new Validator(sync, async);
 }
 
 export function items(...functionsOrValidators) {
   const ItemSchema = schema(...functionsOrValidators);
-
-  return new Validator((value) => {
-    if (!Array.isArray(value)) {
-      throw new ValidationError({
-        message: "value must be an array",
-        details: { value, valueType: typeof value },
-      });
-    }
-
-    const items = value;
+  
+  function sync(value) {
+    assertArray(value);
     const errors = [];
-
-    for (let index = 0; index < items.length; index++) {
-      const result = ItemSchema.validate(items[index]);
+    for (const [indexKey, item] of Object.entries(value)) {
+      const index = Number(indexKey);
+      const result = ItemSchema.validate(item);
       if (result.valid) {
-        items[index] = result.value;
+        value[index] = result.value;
       } else {
-        for (const error of result.errors) {
-          error.path = [index].concat(error.path ?? []);
-          errors.push(error);
-        }
+        pushWithPath(errors, result.errors, index);
       }
     }
-
     if (errors.length > 0) throw errors;
-    return items;
+    return value;
+  }
+  
+  async function async(value) {
+    assertArray(value);
+    const errors = [];
+    for (const [indexKey, item] of Object.entries(value)) {
+      const index = Number(indexKey);
+      const result = await ItemSchema.validateAsync(item);
+      if (result.valid) {
+        value[index] = result.value;
+      } else {
+        pushWithPath(errors, result.errors, index);
+      }
+    }
+    if (errors.length > 0) throw errors;
+    return value;
+  }
+  
+  return new Validator(sync, async);
+}
+
+function handleKeyResult(value, name, result) {
+  if (result.valid) return { ...value, [name]: result.value };
+  throw result.errors.map((error) => {
+    error.path = [name].concat(error.path ?? []);
+    return error;
   });
+}
+
+function requireObjectLike(value, name) {
+  if (value === null || value === undefined || typeof value !== "object") {
+    const got = typeOf(value);
+    throw new WrongTypeValidationError({
+      message: `key("${String(name)}") expected an object, got ${got}`,
+      details: { value, valueType: got, keyName: name },
+    });
+  }
+}
+
+function assertArray(value) {
+  if (!Array.isArray(value)) {
+    throw new ValidationError({
+      message: "value must be an array",
+      details: { value, valueType: typeof value },
+    });
+  }
+}
+
+function pushWithPath(errors, itemErrors, index) {
+  for (const error of itemErrors) {
+    error.path = [index].concat(error.path ?? []);
+    errors.push(error);
+  }
+}
+
+function typeOf(value) {
+  if (value === null) return "null";
+  return typeof value;
 }
 
 export function hasKey(key) {
   const isStringOrSymbol =
     typeof key === "string" || typeof key === "symbol";
-
+    
   if (!isStringOrSymbol) {
     throw Object.assign(
       new TypeError(
@@ -263,13 +344,13 @@ export function hasKey(key) {
       { value: key },
     );
   }
-
+  
   return new Validator((value) => {
     const defined =
       value !== null &&
       value !== undefined &&
       value[key] !== undefined;
-
+      
     if (!defined) {
       throw new MissingKeyError({
         message: `Expected key "${String(key)}" is missing`,
@@ -283,37 +364,65 @@ export function hasKey(key) {
 
 export function required(...functionsOrValidators) {
   const Inner = schema(...functionsOrValidators);
-  return new Validator((value) => {
-    if (
-      value === null ||
-      value === undefined ||
-      Number.isNaN(value) ||
-      value?.valueOf?.() === "" ||
-      value?.length === 0 ||
-      value?.size === 0 ||
-      isEmpty(value)
-    ) {
-      throw new RequiredError({
-        message: "Value is required",
-        details: { value },
-      });
-    }
+  
+  function sync(value) {
+    if (isMissing(value)) throw missingError(value);
     const result = Inner.validate(value);
     if (result.valid) return result.value;
     throw result.errors;
-  });
+  }
+  
+  async function async(value) {
+    if (isMissing(value)) throw missingError(value);
+    const result = await Inner.validateAsync(value);
+    if (result.valid) return result.value;
+    throw result.errors;
+  }
+  
+  return new Validator(sync, async);
 }
 
 export function optional(...functionsOrValidators) {
   const Inner = schema(...functionsOrValidators);
-  const emptyValues = [undefined, null, ""];
-
-  return new Validator((value) => {
-    if (emptyValues.includes(value)) return;
+  
+  function sync(value) {
+    if (isOptionalEmpty(value)) return;
     const result = Inner.validate(value);
     if (result.valid) return result.value;
     throw result.errors;
+  }
+  
+  async function async(value) {
+    if (isOptionalEmpty(value)) return;
+    const result = await Inner.validateAsync(value);
+    if (result.valid) return result.value;
+    throw result.errors;
+  }
+  
+  return new Validator(sync, async);
+}
+
+function isMissing(value) {
+  return (
+    value === null ||
+    value === undefined ||
+    Number.isNaN(value) ||
+    value?.valueOf?.() === "" ||
+    value?.length === 0 ||
+    value?.size === 0 ||
+    isEmpty(value)
+  );
+}
+
+function missingError(value) {
+  return new RequiredError({
+    message: "Value is required",
+    details: { value },
   });
+}
+
+function isOptionalEmpty(value) {
+  return value === undefined || value === null || value === "";
 }
 
 
@@ -337,8 +446,13 @@ export function type(Type) {
 
 type.oneOf = function typeOneOf(...allowedTypes) {
   return new Validator((value) => {
-    if (!allowedTypes.some((T) => value instanceof T)) {
-      const typeNames = allowedTypes.map((T) => T.name ?? T);
+    const matches = allowedTypes.some(
+      (allowed) => value instanceof allowed,
+    );
+    if (!matches) {
+      const typeNames = allowedTypes.map(
+        (allowed) => allowed.name ?? allowed,
+      );
       throw new ValidationError({
         message: `Value must be one of: ${serialComma(typeNames, "or")}`,
         details: { value, allowedTypes },
@@ -349,28 +463,28 @@ type.oneOf = function typeOneOf(...allowedTypes) {
 
 type.to = function toType(Type) {
   const conversions = new Map();
-  conversions.set(Array, (v) => Array.from(v));
-  conversions.set(BigInt, (v) => BigInt(v));
-  conversions.set(Boolean, (v) => Boolean(v));
-  conversions.set(Date, (v) => new Date(v));
-  conversions.set(Function, (v) => Function(v));
-  conversions.set(Map, (v) => new Map(v));
-  conversions.set(Number, (v) => Number(v));
-  conversions.set(Object, (v) => Object(v));
-  conversions.set(Promise, (v) => Promise.resolve(v));
-  conversions.set(RegExp, (v) => new RegExp(v));
-  conversions.set(Set, (v) => new Set(v));
-  conversions.set(String, (v) => String(v));
-  conversions.set(Symbol, (v) => Symbol.for(v));
-  conversions.set(Uint8Array, (v) => new Uint8Array(v));
-
+  conversions.set(Array, (input) => Array.from(input));
+  conversions.set(BigInt, (input) => BigInt(input));
+  conversions.set(Boolean, (input) => Boolean(input));
+  conversions.set(Date, (input) => new Date(input));
+  conversions.set(Function, (input) => Function(input));
+  conversions.set(Map, (input) => new Map(input));
+  conversions.set(Number, (input) => Number(input));
+  conversions.set(Object, (input) => Object(input));
+  conversions.set(Promise, (input) => Promise.resolve(input));
+  conversions.set(RegExp, (input) => new RegExp(input));
+  conversions.set(Set, (input) => new Set(input));
+  conversions.set(String, (input) => String(input));
+  conversions.set(Symbol, (input) => Symbol.for(input));
+  conversions.set(Uint8Array, (input) => new Uint8Array(input));
+  
   const convert = conversions.get(Type) ?? Type;
-
+  
   if (typeof convert !== "function") {
     const typeName = Type?.name ?? Type;
     throw new TypeError(`type.to(): unsupported type: ${typeName}`);
   }
-
+  
   return new Validator((value) => convert(value));
 };
 
@@ -392,12 +506,14 @@ export function minLength(minLen) {
     if (typeof value?.length !== "number") {
       throw new MinLengthError({
         message: "Value must have a numeric length property",
+        minLength: minLen,
         details: { value, minLength: minLen },
       });
     }
     if (value.length < minLen) {
       throw new MinLengthError({
         message: `Length of value must be at least ${minLen}`,
+        minLength: minLen,
         details: { value, minLength: minLen },
       });
     }
@@ -411,6 +527,12 @@ export function string() {
 
 string.minLength = function stringMinLength(minLen) {
   return new Validator((value) => {
+    if (typeof value !== "string") {
+      throw new MinimumStringLengthError({
+        message: `Value must be a string to check minLength`,
+        details: { value, valueType: typeof value, minLength: minLen },
+      });
+    }
     if (value.length < minLen) {
       throw new MinimumStringLengthError({
         message: `String must be at least ${minLen} characters long`,
@@ -422,6 +544,12 @@ string.minLength = function stringMinLength(minLen) {
 
 string.maxLength = function stringMaxLength(maxLen) {
   return new Validator((value) => {
+    if (typeof value !== "string") {
+      throw new MaximumStringLengthError({
+        message: `Value must be a string to check maxLength`,
+        details: { value, valueType: typeof value, maxLength: maxLen },
+      });
+    }
     if (value.length > maxLen) {
       throw new MaximumStringLengthError({
         message: `String must be no longer than ${maxLen} characters`,
@@ -436,12 +564,12 @@ string.url = function stringURL() {
     try {
       const parsedUrl = new URL(prependHttp(value));
       const parsedDomain = parseDomain(parsedUrl.hostname);
-
+      
       const domainValid =
         Boolean(parsedDomain.domain) &&
         Boolean(parsedDomain.topLevelDomains?.length) &&
         parsedDomain.type === "LISTED";
-
+        
       if (!domainValid) {
         throw new InvalidURLError({
           message: "This doesn't look like a URL",
@@ -480,9 +608,9 @@ string.isoDate = function stringIsoDate() {
       });
     }
     const date = new Date(value);
-    const roundTrip = Number.isNaN(date.getTime())
-      ? null
-      : date.toISOString().slice(0, 10);
+    const roundTrip = Number.isNaN(date.getTime()) ?
+      null :
+      date.toISOString().slice(0, 10);
     if (roundTrip !== value) {
       throw new InvalidISODateError({
         message: "ISO date is invalid",
@@ -499,6 +627,12 @@ export function number() {
 
 number.min = function numberMin(min) {
   return new Validator((value) => {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      throw new MinimumNumberError({
+        message: `Value must be a number to check min`,
+        details: { value, valueType: typeof value, min },
+      });
+    }
     if (value < min) {
       throw new MinimumNumberError({
         message: `Value must be at least ${min}`,
@@ -510,6 +644,12 @@ number.min = function numberMin(min) {
 
 number.max = function numberMax(max) {
   return new Validator((value) => {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      throw new MaximumNumberError({
+        message: `Value must be a number to check max`,
+        details: { value, valueType: typeof value, max },
+      });
+    }
     if (value > max) {
       throw new MaximumNumberError({
         message: `Value must be no larger than ${max}`,
@@ -567,7 +707,7 @@ number.nonNegative = function numberNonNegative() {
 export function isEmpty(value) {
   const EMPTY = true;
   const NOT_EMPTY = false;
-
+  
   if (isPrimitive(value)) return NOT_EMPTY;
   if (typeof value.length === "number") {
     return value.length === 0 ? EMPTY : NOT_EMPTY;
@@ -575,27 +715,41 @@ export function isEmpty(value) {
   if (typeof value.size === "number") {
     return value.size === 0 ? EMPTY : NOT_EMPTY;
   }
-
+  
   try {
-    for (const _ of value) return NOT_EMPTY;
+    for (const item of value) {
+      void item;
+      return NOT_EMPTY;
+    }
     return EMPTY;
-  } catch (_) {
+  } catch {
     // not iterable
   }
-
+  
   try {
-    for (const _ of Object.entries(value)) return NOT_EMPTY;
+    for (const entry of Object.entries(value)) {
+      void entry;
+      return NOT_EMPTY;
+    }
     return EMPTY;
-  } catch (_) {
+  } catch {
     // not enumerable
   }
-
+  
   return NOT_EMPTY;
 }
 
 
 export const mapAdapter = (fn) => new Validator(fn);
 
+
+function isThenable(value) {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof value.then === "function"
+  );
+}
 
 function ensureArray(value) {
   return Array.isArray(value) ? value : [value];

--- a/schema.js
+++ b/schema.js
@@ -740,9 +740,6 @@ export function isEmpty(value) {
 }
 
 
-export const mapAdapter = (fn) => new Validator(fn);
-
-
 function isThenable(value) {
   return (
     value !== null &&

--- a/schema.js
+++ b/schema.js
@@ -627,14 +627,13 @@ export function number() {
 
 number.min = function numberMin(min) {
   return new Validator((value) => {
-    const num = coerceFiniteNumber(value);
-    if (num === null) {
+    if (!isRealNumber(value)) {
       throw new MinimumNumberError({
         message: "Value must be a number",
         details: { value, valueType: typeof value, min },
       });
     }
-    if (num < min) {
+    if (value < min) {
       throw new MinimumNumberError({
         message: `Value must be at least ${min}`,
         details: { value, min },
@@ -645,14 +644,13 @@ number.min = function numberMin(min) {
 
 number.max = function numberMax(max) {
   return new Validator((value) => {
-    const num = coerceFiniteNumber(value);
-    if (num === null) {
+    if (!isRealNumber(value)) {
       throw new MaximumNumberError({
         message: "Value must be a number",
         details: { value, valueType: typeof value, max },
       });
     }
-    if (num > max) {
+    if (value > max) {
       throw new MaximumNumberError({
         message: `Value must be no larger than ${max}`,
         details: { value, max },
@@ -663,7 +661,7 @@ number.max = function numberMax(max) {
 
 number.finite = function numberFinite() {
   return new Validator((value) => {
-    if (coerceFiniteNumber(value) === null) {
+    if (!Number.isFinite(value)) {
       throw new FiniteNumberError({
         message: "Value must be a finite number",
         details: { value },
@@ -674,8 +672,7 @@ number.finite = function numberFinite() {
 
 number.integer = function numberInteger() {
   return new Validator((value) => {
-    const num = coerceFiniteNumber(value);
-    if (num === null || !Number.isInteger(num)) {
+    if (!Number.isInteger(value)) {
       throw new NonIntegerError({
         message: "Value must be an integer",
         details: { value },
@@ -686,8 +683,7 @@ number.integer = function numberInteger() {
 
 number.positive = function numberPositive() {
   return new Validator((value) => {
-    const num = coerceFiniteNumber(value);
-    if (num === null || num <= 0) {
+    if (!isRealNumber(value) || value <= 0) {
       throw new PositiveNumberError({
         message: "Value must be a positive number",
         details: { value },
@@ -698,8 +694,7 @@ number.positive = function numberPositive() {
 
 number.nonNegative = function numberNonNegative() {
   return new Validator((value) => {
-    const num = coerceFiniteNumber(value);
-    if (num === null || num < 0) {
+    if (!isRealNumber(value) || value < 0) {
       throw new NonNegativeNumberError({
         message: "Value must be a non-negative number",
         details: { value },
@@ -708,17 +703,8 @@ number.nonNegative = function numberNonNegative() {
   });
 };
 
-function coerceFiniteNumber(value) {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : null;
-  }
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (trimmed.length === 0) return null;
-    const num = Number(trimmed);
-    return Number.isFinite(num) ? num : null;
-  }
-  return null;
+function isRealNumber(value) {
+  return typeof value === "number" && !Number.isNaN(value);
 }
 
 

--- a/schema.test.js
+++ b/schema.test.js
@@ -776,44 +776,31 @@ await test("string.* type guards", async (ctx) => {
 });
 
 
-await test("number.* coercion", async (ctx) => {
-  await ctx.test("accepts numeric strings (forms pass strings)", () => {
-    assert.equal(number.min(1).validate("5").valid, true);
-    assert.equal(number.min(10).validate("5").valid, false);
-    assert.equal(number.max(10).validate("5").valid, true);
-    assert.equal(number.max(1).validate("5").valid, false);
-    assert.equal(number.integer().validate("5").valid, true);
-    assert.equal(number.positive().validate("5").valid, true);
-    assert.equal(number.nonNegative().validate("0").valid, true);
+await test("number.* type strictness", async (ctx) => {
+  await ctx.test("rejects strings; use type.to(Number) to coerce", () => {
+    assert.equal(number.min(1).validate("5").valid, false);
+    assert.equal(number.max(10).validate("5").valid, false);
+    assert.equal(number.positive().validate("5").valid, false);
+    assert.equal(number.integer().validate("5").valid, false);
+    
+    const Coerced = schema(type.to(Number), number.min(1));
+    const result = Coerced.validate("5");
+    assert.equal(result.valid, true);
+    assert.equal(result.value, 5);
   });
   
-  await ctx.test("accepts whitespace and negative/decimal strings", () => {
-    assert.equal(number.min(1).validate(" 5 ").valid, true);
-    assert.equal(number.min(-10).validate("-3.14").valid, true);
+  await ctx.test("rejects NaN across every bound check", () => {
+    assert.equal(number.min(1).validate(NaN).valid, false);
+    assert.equal(number.max(1).validate(NaN).valid, false);
+    assert.equal(number.positive().validate(NaN).valid, false);
+    assert.equal(number.nonNegative().validate(NaN).valid, false);
   });
   
-  await ctx.test("rejects non-numeric strings", () => {
-    assert.equal(number.min(1).validate("abc").valid, false);
-    assert.equal(number.min(1).validate("5abc").valid, false);
-    assert.equal(number.min(1).validate("").valid, false);
-    assert.equal(number.min(1).validate("   ").valid, false);
-  });
-  
-  await ctx.test("rejects NaN, Infinity, null, booleans, objects", () => {
-    const bad = [
-      NaN, Infinity, -Infinity,
-      null, undefined,
-      true, false,
-      [], {},
-    ];
+  await ctx.test("rejects null, undefined, booleans, objects", () => {
+    const bad = [null, undefined, true, false, [], {}];
     for (const input of bad) {
       assert.equal(number.min(1).validate(input).valid, false);
     }
-  });
-  
-  await ctx.test("number.integer rejects non-integer strings", () => {
-    assert.equal(number.integer().validate("5.5").valid, false);
-    assert.equal(number.integer().validate("5").valid, true);
   });
 });
 

--- a/schema.test.js
+++ b/schema.test.js
@@ -1,248 +1,703 @@
-import { test } from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
-  schema,
+  ValidationError, ValidationResult, Validator,
+  schema, key, items, hasKey, MissingKeyError,
+  required, RequiredError, optional,
+  minLength, MinLengthError,
+  type, WrongTypeValidationError,
+  oneOf,
+  string, MinimumStringLengthError, MaximumStringLengthError,
+  InvalidURLError, InvalidEmailError, InvalidISODateError,
+  number, MinimumNumberError, MaximumNumberError,
+  FiniteNumberError, NonIntegerError,
+  PositiveNumberError, NonNegativeNumberError,
+  isEmpty,
   mapAdapter,
-  key,
-  hasKeys,
-  items,
-  is,
-  isUrl,
-  required,
-  isType,
-  as,
-  to,
-  isOneOf,
-  length,
 } from "./schema.js";
 
-test("module exports", () => {
-  assert.strictEqual(typeof schema, "function");
-  assert.strictEqual(typeof mapAdapter, "function");
-  assert.strictEqual(typeof key, "function");
-  assert.strictEqual(typeof hasKeys, "function");
-  assert.strictEqual(typeof items, "function");
-  assert.strictEqual(typeof is, "function");
-  assert.strictEqual(typeof isUrl, "function");
-  assert.strictEqual(typeof required, "function");
-  assert.strictEqual(typeof isType, "function");
-  assert.strictEqual(typeof as, "function");
-  assert.strictEqual(typeof to, "function");
-  assert.strictEqual(typeof isOneOf, "function");
-  assert.strictEqual(typeof length, "function");
+
+await test("ValidationError", async () => {
+  const error = new ValidationError({ message: "Invalid value" });
+  assert.equal(error.message, "Invalid value");
+  assert.deepEqual(error.path, []);
+
+  const stringForm = new ValidationError("Bad input", { code: "x" });
+  assert.equal(stringForm.message, "Bad input");
+  assert.equal(stringForm.code, "x");
 });
 
-test("schema() returns a function", () => {
-  assert.strictEqual(typeof schema(), "function");
+
+await test("ValidationResult", async (t) => {
+  await t.test(".ok()", () => {
+    const result = ValidationResult.ok("valid data");
+    assert.equal(result.valid, true);
+    assert.equal(result.value, "valid data");
+    assert.equal("errors" in result, false);
+  });
+
+  await t.test(".error()", () => {
+    const errs = [
+      new ValidationError({ message: "Error 1" }),
+      new ValidationError({ message: "Error 2" }),
+    ];
+    const result = ValidationResult.error(errs);
+    assert.equal(result.valid, false);
+    assert.deepEqual(result.errors, errs);
+    assert.equal("value" in result, false);
+  });
+
+  await t.test("constructor asserts boolean valid", () => {
+    assert.throws(
+      () => new ValidationResult({ valid: "yes", value: 1 }),
+      TypeError,
+    );
+  });
 });
 
-test("schema() has sync & async validate, test, and assert functions", () => {
-  const s = schema();
-  assert.strictEqual(typeof s.validate, "function");
-  assert.strictEqual(typeof s.test, "function");
-  assert.strictEqual(typeof s.assert, "function");
-  assert.strictEqual(typeof s.validateAsync, "function");
-  assert.strictEqual(typeof s.testAsync, "function");
-  assert.strictEqual(typeof s.assertAsync, "function");
+
+await test("Validator", async (t) => {
+  function createValidator() {
+    return new Validator((value) => {
+      if (value < 0) {
+        throw new ValidationError({ message: "Value must be non-negative" });
+      }
+    });
+  }
+
+  function createAsyncValidator() {
+    return new Validator(async (value) => {
+      if (value < 0) {
+        throw new ValidationError("Value must be non-negative");
+      }
+    });
+  }
+
+  await t.test("constructor throws on non-function", () => {
+    assert.throws(() => new Validator("not a function"), TypeError);
+    assert.throws(() => new Validator(42), TypeError);
+  });
+
+  await t.test(".validate() with valid input returns a valid result", () => {
+    const result = createValidator().validate(5);
+    assert.equal(result.valid, true);
+    assert.equal(result.value, 5);
+  });
+
+  await t.test(".validate() with invalid input returns an invalid result", () => {
+    const result = createValidator().validate(-2);
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.length, 1);
+    assert.equal(result.errors.at(0).message, "Value must be non-negative");
+  });
+
+  await t.test(".message() with a string overrides the error message", () => {
+    const result = createValidator().message("Custom message").validate(-3);
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0).message, "Custom message");
+  });
+
+  await t.test(".message() with a function overrides the error message", () => {
+    const result = createValidator().message(() => "From fn").validate(-3);
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0).message, "From fn");
+  });
+
+  await t.test(".validateAsync() with valid input", async () => {
+    const result = await createAsyncValidator().validateAsync(5);
+    assert.equal(result.valid, true);
+    assert.equal(result.value, 5);
+  });
+
+  await t.test(".validateAsync() with invalid input", async () => {
+    const result = await createAsyncValidator().validateAsync(-2);
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.length, 1);
+  });
+
+  await t.test(".test() returns boolean validity", () => {
+    const v = createValidator();
+    assert.equal(v.test(5), true);
+    assert.equal(v.test(-2), false);
+  });
+
+  await t.test(".testAsync() returns boolean validity", async () => {
+    const v = createAsyncValidator();
+    assert.equal(await v.testAsync(5), true);
+    assert.equal(await v.testAsync(-2), false);
+  });
+
+  await t.test(".assert() with valid input doesn't throw", () => {
+    assert.doesNotThrow(() => createValidator().assert(5));
+  });
+
+  await t.test(".assert() with invalid input throws", () => {
+    assert.throws(() => createValidator().assert(-2), ValidationError);
+  });
+
+  await t.test(".assertAsync() with valid input doesn't throw", async () => {
+    await assert.doesNotReject(() => createAsyncValidator().assertAsync(5));
+  });
+
+  await t.test(".assertAsync() with invalid input throws", async () => {
+    await assert.rejects(
+      () => createAsyncValidator().assertAsync(-2),
+      ValidationError,
+    );
+  });
+
+  await t.test("non-ValidationError throws bubble up", () => {
+    const v = new Validator(() => { throw new RangeError("boom"); });
+    assert.throws(() => v.validate(null));
+  });
 });
 
-test("transform functions modify the value", () => {
-  const MySchema = schema(
-    mapAdapter(value => String(value)),
-    mapAdapter(value => value + "1"),
-  );
-  const actual = MySchema.validate(42);
-  const expected = {
-    valid: true,
-    value: "421",
-    errors: [],
-  };
-  assert.deepStrictEqual(actual, expected);
+
+await test("schema()", async (t) => {
+  await t.test("with valid input", () => {
+    const Name = schema(required(), minLength(3));
+    const result = Name.validate("Alice");
+    assert.equal(result.valid, true);
+    assert.equal(result.value, "Alice");
+  });
+
+  await t.test("accepts both plain functions and Validator instances", () => {
+    const plainFn = (v) => {
+      if (v !== "ok") throw new ValidationError("not ok");
+    };
+    const vld = new Validator((v) => {
+      if (typeof v !== "string") throw new ValidationError("not string");
+    });
+    const S = schema(plainFn, vld);
+    assert.equal(S.validate("ok").valid, true);
+    assert.equal(S.validate("nope").valid, false);
+  });
+
+  await t.test("throws TypeError on non-function argument", () => {
+    assert.throws(() => schema("not a fn"), TypeError);
+  });
 });
 
-test("schema().validate() collects and returns errors", () => {
-  const MySchema = schema(
-    is(Object),
-  );
-  const actual = MySchema.validate(42);
-  const expected = {
-    valid: false,
-    value: 42,
-    errors: [{
-      code: "is.type",
-      path: [],
-      message: "wrong type: expected object",
-      expectedType: "object",
-      value: 42,
-    }],
-  };
-  assert.deepStrictEqual(actual, expected);
-});
 
-test("hasKeys() returns errors when keys are missing", () => {
-  const MySchema = schema(
-    hasKeys("foo", "bar"),
-  );
-  const actual = MySchema.validate({});
-  const expected = {
-    valid: false,
-    value: {},
-    errors: [{
-      code: "key.missing",
-      path: [],
-      message: `expected key "foo" missing`,
-      key: "foo",
-      value: {},
-    }, {
-      code: "key.missing",
-      path: [],
-      message: `expected key "bar" missing`,
-      key: "bar",
-      value: {},
-    }],
-  };
-  assert.deepStrictEqual(actual, expected);
-});
-
-test("key() transforms value", () => {
-  const MySchema = schema(
-    key(
-      "name",
-      mapAdapter(value => `Hello, ${value}!`),
-      mapAdapter(value => String(value).toUpperCase()),
-    ),
-  );
-  const actual = MySchema.validate({ name: "World" });
-  const expected = {
-    valid: true,
-    value: { name: "HELLO, WORLD!" },
-    errors: [],
-  };
-  assert.deepStrictEqual(actual, expected);
-});
-
-test("key() collects errors", () => {
-  const MySchema = schema(
-    key("foo", is(Object)),
-  );
-  const actual = MySchema.validate({ foo: 42 });
-  const expected = {
-    valid: false,
-    value: { foo: 42 },
-    errors: [{
-      code: "is.type",
-      path: ["foo"],
-      message: "wrong type: expected object",
-      expectedType: "object",
-      value: 42,
-    }],
-  };
-  assert.deepStrictEqual(actual, expected);
-});
-
-test("key() is recursive", () => {
-  const MySchema = schema(
-    key(
-      "name",
-      is(Object),
-      key("first", is(String)),
-    ),
-  );
-  const actual = MySchema.validate({ name: { first: 42 } });
-  const expected = {
-    valid: false,
-    value: { name: { first: 42 } },
-    errors: [{
-      code: "is.type",
-      path: ["name", "first"],
-      message: "wrong type: expected string",
-      expectedType: "string",
-      value: 42,
-    }],
-  };
-  assert.deepStrictEqual(actual, expected);
-});
-
-test("items() transform values", () => {
-  const MySchema = schema(
-    items(
-      mapAdapter(value => value * 2),
-      mapAdapter(value => String(value) + String(value)),
-      mapAdapter(Number),
-    ),
-  );
-  const actual = MySchema.validate([1, 2, 3]);
-  const expected = {
-    valid: true,
-    value: [22, 44, 66],
-    errors: [],
-  };
-  assert.deepStrictEqual(actual, expected);
-});
-
-test("items() collects errors", () => {
-  const MySchema = schema(
-    items(is(Number)),
-  );
-  const actual = MySchema.validate([1, 2, "3", 4, "5"]);
-  const expected = {
-    valid: false,
-    value: [1, 2, "3", 4, "5"],
-    errors: [{
-      code: "is.type",
-      path: [2],
-      message: "wrong type: expected number",
-      expectedType: "number",
-      value: "3",
-    }, {
-      code: "is.type",
-      path: [4],
-      message: "wrong type: expected number",
-      expectedType: "number",
-      value: "5",
-    }],
-  };
-  assert.deepStrictEqual(actual, expected);
-});
-
-test("schema().test() returns true if valid, false otherwise", () => {
-  const MySchema = schema(
-    is(Object),
-  );
-  assert.strictEqual(MySchema.test(42), false);
-  assert.strictEqual(MySchema.test({}), true);
-  assert.strictEqual(MySchema.test("hi"), false);
-});
-
-test("schema().assert() throws if invalid, doesn't otherwise", () => {
-  const MySchema = schema(
-    is(Object),
-  );
-  assert.throws(() => MySchema.assert(42));
-  assert.throws(() => MySchema.assert("hi"));
-  MySchema.assert({});
-});
-
-test("isUrl() validates humanized URLs", () => {
-  const MySchema = schema(
-    isUrl(),
+await test("key()", async (t) => {
+  const UserSchema = schema(
+    key("username", required(), minLength(3)),
+    key("age", required()),
   );
 
-  assert.ok(MySchema.validate("google.com").valid);
-  assert.ok(MySchema.validate("google.com/path").valid);
-  assert.ok(MySchema.validate("www.google.com").valid);
-  assert.ok(MySchema.validate("http://google.com").valid);
-  assert.ok(MySchema.validate("https://google.com").valid);
-  assert.ok(MySchema.validate("ftp://google.com").valid);
+  await t.test("with valid input", () => {
+    const result = UserSchema.validate({ username: "alice", age: 30 });
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.value, { username: "alice", age: 30 });
+  });
 
-  assert.ok(!MySchema.validate("foo").valid);
-  assert.ok(!MySchema.validate("http").valid);
-  assert.ok(!MySchema.validate("http:").valid);
-  assert.ok(!MySchema.validate("http://").valid);
-  assert.ok(!MySchema.validate("/bar").valid);
-  assert.ok(!MySchema.validate("foo/bar").valid);
+  await t.test("with missing key surfaces errors with paths", () => {
+    const result = UserSchema.validate({ age: 30 });
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0) instanceof RequiredError, true);
+    assert.deepEqual(result.errors.at(0).path, ["username"]);
+  });
 
-  assert.ok(MySchema.validate("").valid);
-  assert.ok(MySchema.validate(null).valid);
-  assert.ok(MySchema.validate(undefined).valid);
+  await t.test("nested key()s with valid input", () => {
+    const Nested = schema(key("foo", key("bar", required())));
+    const result = Nested.validate({ foo: { bar: 42 } });
+    assert.equal(result.valid, true);
+  });
+
+  await t.test("nested key()s propagate path", () => {
+    const Nested = schema(key("foo", key("bar", required())));
+    const result = Nested.validate({ foo: {} });
+    assert.equal(result.valid, false);
+    assert.deepEqual(result.errors.at(0).path, ["foo", "bar"]);
+  });
+});
+
+
+await test("items()", async (t) => {
+  function allCaps() {
+    return new Validator((value) => {
+      if (value !== value.toUpperCase()) {
+        throw new ValidationError("Value must be all caps");
+      }
+    });
+  }
+
+  const ListSchema = schema(items(allCaps()));
+
+  await t.test("with valid input", () => {
+    const result = ListSchema.validate(["FOO", "BAR", "BAZ"]);
+    assert.equal(result.valid, true);
+  });
+
+  await t.test("with invalid input at index 1", () => {
+    const result = ListSchema.validate(["FOO", "Bar", "BAZ"]);
+    assert.equal(result.valid, false);
+    assert.deepEqual(result.errors.at(0).path, [1]);
+  });
+
+  await t.test("rejects non-arrays", () => {
+    const result = ListSchema.validate("not an array");
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0) instanceof ValidationError, true);
+  });
+});
+
+
+await test("hasKey()", async (t) => {
+  const UserSchema = schema(hasKey("username"));
+
+  await t.test("with key present", () => {
+    const result = UserSchema.validate({ username: "alice" });
+    assert.equal(result.valid, true);
+  });
+
+  await t.test("with key missing", () => {
+    const result = UserSchema.validate({ name: "alice" });
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0) instanceof MissingKeyError, true);
+  });
+
+  await t.test("with symbol key", () => {
+    const sym = Symbol("k");
+    const S = schema(hasKey(sym));
+    assert.equal(S.validate({ [sym]: 1 }).valid, true);
+    assert.equal(S.validate({}).valid, false);
+  });
+
+  await t.test("throws TypeError if key isn't a string or symbol", () => {
+    assert.throws(() => hasKey(123), TypeError);
+  });
+});
+
+
+await test("required()", async (t) => {
+  await t.test("with valid values", () => {
+    const v = required();
+    assert.equal(v.validate("hello").valid, true);
+    assert.equal(v.validate(0).valid, true);
+    assert.equal(v.validate(false).valid, true);
+    assert.equal(v.validate(true).valid, true);
+  });
+
+  await t.test("with invalid values", () => {
+    const v = required();
+    assert.equal(v.validate(undefined).valid, false);
+    assert.equal(v.validate(null).valid, false);
+    assert.equal(v.validate("").valid, false);
+    assert.equal(v.validate([]).valid, false);
+    assert.equal(v.validate({}).valid, false);
+    assert.equal(v.validate(NaN).valid, false);
+  });
+
+  await t.test("with nested validators", async (tt) => {
+    const S = schema(
+      required(type(Object), key("foo", string.minLength(3))),
+    );
+
+    await tt.test("valid input passes", () => {
+      assert.equal(S.validate({ foo: "bar" }).valid, true);
+    });
+
+    await tt.test("missing value throws RequiredError, inner skipped", () => {
+      const result = S.validate(null);
+      assert.equal(result.valid, false);
+      assert.equal(result.errors.length, 1);
+      assert.equal(result.errors.at(0) instanceof RequiredError, true);
+    });
+
+    await tt.test("present but invalid runs inner validators", () => {
+      const result = S.validate({ foo: "hi" });
+      assert.equal(result.valid, false);
+      assert.equal(result.errors.at(0) instanceof MinimumStringLengthError, true);
+      assert.deepEqual(result.errors.at(0).path, ["foo"]);
+    });
+  });
+});
+
+
+await test("optional()", async (t) => {
+  const S = schema(optional(string.minLength(5)));
+
+  await t.test("empty values pass", () => {
+    assert.equal(S.validate(undefined).valid, true);
+    assert.equal(S.validate(null).valid, true);
+    assert.equal(S.validate("").valid, true);
+  });
+
+  await t.test("non-empty valid value passes", () => {
+    assert.equal(S.validate("hello").valid, true);
+  });
+
+  await t.test("non-empty invalid value fails", () => {
+    assert.equal(S.validate("hi").valid, false);
+  });
+});
+
+
+await test("type()", async (t) => {
+  await t.test("with valid input", () => {
+    assert.equal(type(Object).validate({}).valid, true);
+    assert.equal(type(Number).validate(42).valid, true);
+    assert.equal(type(Array).validate([]).valid, true);
+    assert.equal(type(String).validate("s").valid, true);
+    assert.equal(type("string").validate("s").valid, true);
+  });
+
+  await t.test("with invalid input", () => {
+    assert.equal(type(Object).validate("hi").valid, false);
+    assert.equal(type(Number).validate({}).valid, false);
+    const result = type(Object).validate("hi");
+    assert.equal(
+      result.errors.at(0) instanceof WrongTypeValidationError,
+      true,
+    );
+  });
+});
+
+
+await test("type.oneOf()", async (t) => {
+  class A {}
+  class B {}
+  class C {}
+
+  const S = schema(type.oneOf(A, B, C));
+
+  await t.test("with valid input", () => {
+    assert.equal(S.validate(new A()).valid, true);
+    assert.equal(S.validate(new B()).valid, true);
+    assert.equal(S.validate(new C()).valid, true);
+  });
+
+  await t.test("with invalid input", () => {
+    assert.equal(S.validate("hello").valid, false);
+    assert.equal(S.validate(null).valid, false);
+    assert.equal(S.validate(undefined).valid, false);
+  });
+});
+
+
+await test("type.to()", async (t) => {
+  await t.test("to Boolean", () => {
+    assert.equal(type.to(Boolean).validate("foo").value, true);
+    assert.equal(type.to(Boolean).validate("").value, false);
+  });
+
+  await t.test("to String", () => {
+    assert.equal(type.to(String).validate(42).value, "42");
+    assert.equal(type.to(String).validate(0).value, "0");
+    assert.equal(type.to(String).validate([1, 2, 3]).value, "1,2,3");
+  });
+
+  await t.test("numeric string to Number", () => {
+    const r = type.to(Number).validate("42");
+    assert.equal(r.valid, true);
+    assert.equal(r.value, 42);
+  });
+
+  await t.test("non-numeric string to Number is NaN but still valid", () => {
+    const r = type.to(Number).validate("not-a-number");
+    assert.equal(r.valid, true);
+    assert.equal(Number.isNaN(r.value), true);
+  });
+
+  await t.test("to Object wraps null", () => {
+    const r = type.to(Object).validate(null);
+    assert.deepEqual(r.value, {});
+  });
+
+  await t.test("to Array", () => {
+    const r = type.to(Array).validate("foo");
+    assert.deepEqual(r.value, ["f", "o", "o"]);
+  });
+
+  await t.test("to Date", () => {
+    const r = type.to(Date).validate("2021-01-01");
+    assert.equal(r.value instanceof Date, true);
+    assert.equal(Number.isNaN(r.value.getTime()), false);
+  });
+
+  await t.test("to BigInt", () => {
+    const r = type.to(BigInt).validate("42");
+    assert.equal(r.value, 42n);
+  });
+
+  await t.test("unsupported type throws TypeError", () => {
+    assert.throws(() => type.to("banana"), TypeError);
+  });
+});
+
+
+await test("oneOf()", async (t) => {
+  const S = schema(oneOf("red", "green", "blue"));
+
+  await t.test("with valid input", () => {
+    assert.equal(S.validate("red").valid, true);
+    assert.equal(S.validate("green").valid, true);
+  });
+
+  await t.test("with invalid input", () => {
+    const result = S.validate("yellow");
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0) instanceof ValidationError, true);
+  });
+});
+
+
+await test("minLength() (generic)", async (t) => {
+  await t.test("with valid values", () => {
+    const v = minLength(5);
+    assert.equal(v.validate("hello").valid, true);
+    assert.equal(v.validate(["h", "e", "l", "l", "o"]).valid, true);
+  });
+
+  await t.test("with invalid values", () => {
+    const v = minLength(5);
+    assert.equal(v.validate("hi").valid, false);
+    assert.equal(v.validate(["h", "i"]).valid, false);
+  });
+
+  await t.test("with message override reading details", () => {
+    const v = minLength(3).message(
+      (error) => `Must be at least ${error.details.minLength} chars`,
+    );
+    const result = v.validate("a");
+    assert.equal(result.errors.at(0).message, "Must be at least 3 chars");
+  });
+
+  await t.test("rejects values without numeric length", () => {
+    const v = minLength(3);
+    assert.equal(v.validate(42).valid, false);
+  });
+});
+
+
+await test("string.minLength()", async () => {
+  const S = schema(string.minLength(3));
+  assert.equal(S.validate("hello").valid, true);
+  const result = S.validate("hi");
+  assert.equal(result.valid, false);
+  assert.equal(result.errors.at(0) instanceof MinimumStringLengthError, true);
+});
+
+
+await test("string.maxLength()", async () => {
+  const S = schema(string.maxLength(5));
+  assert.equal(S.validate("hello").valid, true);
+  const result = S.validate("hello world");
+  assert.equal(result.valid, false);
+  assert.equal(result.errors.at(0) instanceof MaximumStringLengthError, true);
+});
+
+
+await test("string.url()", async (t) => {
+  const S = schema(string.url());
+
+  await t.test("bare domain", () => {
+    assert.equal(S.validate("example.com").valid, true);
+  });
+
+  await t.test("full URL", () => {
+    assert.equal(S.validate("https://example.com/path").valid, true);
+  });
+
+  await t.test("URL with port", () => {
+    assert.equal(S.validate("https://example.com:8080").valid, true);
+  });
+
+  await t.test("subdomain accepted", () => {
+    assert.equal(S.validate("api.example.com").valid, true);
+  });
+
+  await t.test("IP address rejected", () => {
+    assert.equal(S.validate("192.168.1.1").valid, false);
+  });
+
+  await t.test("localhost rejected (not listed public domain)", () => {
+    assert.equal(S.validate("localhost").valid, false);
+  });
+
+  await t.test("empty string rejected", () => {
+    const result = S.validate("");
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0) instanceof InvalidURLError, true);
+  });
+
+  await t.test("garbage rejected", () => {
+    assert.equal(S.validate("not-a-url").valid, false);
+  });
+});
+
+
+await test("string.email()", async (t) => {
+  const S = schema(string.email());
+
+  await t.test("with valid input", () => {
+    assert.equal(S.validate("user@example.com").valid, true);
+  });
+
+  await t.test("with invalid inputs", () => {
+    const invalid = [
+      "not-an-email",
+      "user@example",
+      "user@example.",
+      "user@.com",
+      "@example.com",
+      "user@",
+      "@",
+      "example.com",
+      "user@examplecom",
+      "@user@example.com",
+      "",
+      null,
+      undefined,
+    ];
+    for (const v of invalid) {
+      assert.equal(S.validate(v).valid, false, `expected invalid: ${v}`);
+    }
+    const result = S.validate("bad");
+    assert.equal(result.errors.at(0) instanceof InvalidEmailError, true);
+  });
+});
+
+
+await test("string.isoDate()", async (t) => {
+  const S = schema(string.isoDate());
+
+  await t.test("valid dates", () => {
+    assert.equal(S.validate("2024-01-01").valid, true);
+    assert.equal(S.validate("2024-12-31").valid, true);
+    assert.equal(S.validate("2024-02-29").valid, true); // leap year
+    assert.equal(S.validate("2023-08-22").valid, true);
+  });
+
+  await t.test("invalid format", () => {
+    assert.equal(S.validate("2024-1-1").valid, false);
+    assert.equal(S.validate("24-01-01").valid, false);
+    assert.equal(S.validate("2024/01/01").valid, false);
+    assert.equal(S.validate("").valid, false);
+    assert.equal(S.validate("08/22/2023").valid, false);
+    assert.equal(S.validate("22-08-2023").valid, false);
+    const result = S.validate("");
+    assert.equal(result.errors.at(0) instanceof InvalidISODateError, true);
+  });
+
+  await t.test("invalid rollover dates rejected", () => {
+    assert.equal(S.validate("2024-02-30").valid, false);
+    assert.equal(S.validate("2024-13-01").valid, false);
+    assert.equal(S.validate("2023-02-29").valid, false); // non-leap
+    assert.equal(S.validate("2023-12-32").valid, false);
+    assert.equal(S.validate("2024-04-31").valid, false);
+    assert.equal(S.validate("2023-22-08").valid, false);
+  });
+
+  await t.test("non-string rejected", () => {
+    assert.equal(S.validate(42).valid, false);
+    assert.equal(S.validate(null).valid, false);
+  });
+});
+
+
+await test("number.min()", async () => {
+  const S = schema(number.min(10));
+  assert.equal(S.validate(15).valid, true);
+  const result = S.validate(5);
+  assert.equal(result.valid, false);
+  assert.equal(result.errors.at(0) instanceof MinimumNumberError, true);
+});
+
+
+await test("number.max()", async () => {
+  const S = schema(number.max(20));
+  assert.equal(S.validate(15).valid, true);
+  const result = S.validate(25);
+  assert.equal(result.valid, false);
+  assert.equal(result.errors.at(0) instanceof MaximumNumberError, true);
+});
+
+
+await test("number.finite()", async () => {
+  const S = schema(number.finite());
+  assert.equal(S.validate(42).valid, true);
+  const result = S.validate(Infinity);
+  assert.equal(result.valid, false);
+  assert.equal(result.errors.at(0) instanceof FiniteNumberError, true);
+});
+
+
+await test("number.integer()", async () => {
+  const S = schema(number.integer());
+  assert.equal(S.validate(42).valid, true);
+  const result = S.validate(42.5);
+  assert.equal(result.valid, false);
+  assert.equal(result.errors.at(0) instanceof NonIntegerError, true);
+});
+
+
+await test("number.positive()", async () => {
+  const S = schema(number.positive());
+  assert.equal(S.validate(42).valid, true);
+  assert.equal(S.validate(0).valid, false);
+  assert.equal(S.validate(-5).valid, false);
+  const result = S.validate(0);
+  assert.equal(result.errors.at(0) instanceof PositiveNumberError, true);
+});
+
+
+await test("number.nonNegative()", async () => {
+  const S = schema(number.nonNegative());
+  assert.equal(S.validate(42).valid, true);
+  assert.equal(S.validate(0).valid, true);
+  assert.equal(S.validate(-5).valid, false);
+  const result = S.validate(-1);
+  assert.equal(result.errors.at(0) instanceof NonNegativeNumberError, true);
+});
+
+
+await test("isEmpty()", async (t) => {
+  await t.test("primitives are never empty", () => {
+    assert.equal(isEmpty(0), false);
+    assert.equal(isEmpty(false), false);
+    assert.equal(isEmpty("x"), false);
+    assert.equal(isEmpty(42), false);
+  });
+
+  await t.test("strings/arrays use .length", () => {
+    assert.equal(isEmpty(""), false); // string is primitive
+    assert.equal(isEmpty([]), true);
+    assert.equal(isEmpty([1]), false);
+  });
+
+  await t.test("Maps/Sets use .size", () => {
+    assert.equal(isEmpty(new Map()), true);
+    assert.equal(isEmpty(new Map([["a", 1]])), false);
+    assert.equal(isEmpty(new Set()), true);
+    assert.equal(isEmpty(new Set([1])), false);
+  });
+
+  await t.test("plain objects check enumerable properties", () => {
+    assert.equal(isEmpty({}), true);
+    assert.equal(isEmpty({ a: 1 }), false);
+  });
+});
+
+
+await test("mapAdapter()", async (t) => {
+  await t.test("returns a Validator", () => {
+    const v = mapAdapter((x) => x * 2);
+    assert.equal(v instanceof Validator, true);
+  });
+
+  await t.test("transforms the value when fn returns non-undefined", () => {
+    const v = mapAdapter((x) => x * 2);
+    const result = v.validate(5);
+    assert.equal(result.valid, true);
+    assert.equal(result.value, 10);
+  });
+
+  await t.test("passes value through when fn returns undefined", () => {
+    const v = mapAdapter(() => undefined);
+    const result = v.validate(5);
+    assert.equal(result.valid, true);
+    assert.equal(result.value, 5);
+  });
 });

--- a/schema.test.js
+++ b/schema.test.js
@@ -776,16 +776,44 @@ await test("string.* type guards", async (ctx) => {
 });
 
 
-await test("number.* type guards", async (ctx) => {
-  await ctx.test("number.min rejects non-numbers and NaN", () => {
-    assert.equal(number.min(1).validate("5").valid, false);
-    assert.equal(number.min(1).validate(NaN).valid, false);
-    assert.equal(number.min(1).validate(null).valid, false);
+await test("number.* coercion", async (ctx) => {
+  await ctx.test("accepts numeric strings (forms pass strings)", () => {
+    assert.equal(number.min(1).validate("5").valid, true);
+    assert.equal(number.min(10).validate("5").valid, false);
+    assert.equal(number.max(10).validate("5").valid, true);
+    assert.equal(number.max(1).validate("5").valid, false);
+    assert.equal(number.integer().validate("5").valid, true);
+    assert.equal(number.positive().validate("5").valid, true);
+    assert.equal(number.nonNegative().validate("0").valid, true);
   });
   
-  await ctx.test("number.max rejects non-numbers and NaN", () => {
-    assert.equal(number.max(5).validate("1").valid, false);
-    assert.equal(number.max(5).validate(NaN).valid, false);
+  await ctx.test("accepts whitespace and negative/decimal strings", () => {
+    assert.equal(number.min(1).validate(" 5 ").valid, true);
+    assert.equal(number.min(-10).validate("-3.14").valid, true);
+  });
+  
+  await ctx.test("rejects non-numeric strings", () => {
+    assert.equal(number.min(1).validate("abc").valid, false);
+    assert.equal(number.min(1).validate("5abc").valid, false);
+    assert.equal(number.min(1).validate("").valid, false);
+    assert.equal(number.min(1).validate("   ").valid, false);
+  });
+  
+  await ctx.test("rejects NaN, Infinity, null, booleans, objects", () => {
+    const bad = [
+      NaN, Infinity, -Infinity,
+      null, undefined,
+      true, false,
+      [], {},
+    ];
+    for (const input of bad) {
+      assert.equal(number.min(1).validate(input).valid, false);
+    }
+  });
+  
+  await ctx.test("number.integer rejects non-integer strings", () => {
+    assert.equal(number.integer().validate("5.5").valid, false);
+    assert.equal(number.integer().validate("5").valid, true);
   });
 });
 

--- a/schema.test.js
+++ b/schema.test.js
@@ -13,7 +13,6 @@ import {
   FiniteNumberError, NonIntegerError,
   PositiveNumberError, NonNegativeNumberError,
   isEmpty,
-  mapAdapter,
 } from "./schema.js";
 
 
@@ -791,21 +790,16 @@ await test("number.* type guards", async (ctx) => {
 });
 
 
-await test("mapAdapter()", async (ctx) => {
-  await ctx.test("returns a Validator", () => {
-    const vld = mapAdapter((num) => num * 2);
-    assert.equal(vld instanceof Validator, true);
-  });
-  
-  await ctx.test("transforms the value when fn returns non-undefined", () => {
-    const vld = mapAdapter((num) => num * 2);
+await test("Validator as transform", async (ctx) => {
+  await ctx.test("transforms value when fn returns non-undefined", () => {
+    const vld = new Validator((num) => num * 2);
     const result = vld.validate(5);
     assert.equal(result.valid, true);
     assert.equal(result.value, 10);
   });
   
   await ctx.test("passes value through when fn returns undefined", () => {
-    const vld = mapAdapter(() => undefined);
+    const vld = new Validator(() => undefined);
     const result = vld.validate(5);
     assert.equal(result.valid, true);
     assert.equal(result.value, 5);

--- a/schema.test.js
+++ b/schema.test.js
@@ -21,22 +21,22 @@ await test("ValidationError", async () => {
   const error = new ValidationError({ message: "Invalid value" });
   assert.equal(error.message, "Invalid value");
   assert.deepEqual(error.path, []);
-
+  
   const stringForm = new ValidationError("Bad input", { code: "x" });
   assert.equal(stringForm.message, "Bad input");
   assert.equal(stringForm.code, "x");
 });
 
 
-await test("ValidationResult", async (t) => {
-  await t.test(".ok()", () => {
+await test("ValidationResult", async (ctx) => {
+  await ctx.test(".ok()", () => {
     const result = ValidationResult.ok("valid data");
     assert.equal(result.valid, true);
     assert.equal(result.value, "valid data");
     assert.equal("errors" in result, false);
   });
-
-  await t.test(".error()", () => {
+  
+  await ctx.test(".error()", () => {
     const errs = [
       new ValidationError({ message: "Error 1" }),
       new ValidationError({ message: "Error 2" }),
@@ -46,8 +46,8 @@ await test("ValidationResult", async (t) => {
     assert.deepEqual(result.errors, errs);
     assert.equal("value" in result, false);
   });
-
-  await t.test("constructor asserts boolean valid", () => {
+  
+  await ctx.test("constructor asserts boolean valid", () => {
     assert.throws(
       () => new ValidationResult({ valid: "yes", value: 1 }),
       TypeError,
@@ -56,7 +56,7 @@ await test("ValidationResult", async (t) => {
 });
 
 
-await test("Validator", async (t) => {
+await test("Validator", async (ctx) => {
   function createValidator() {
     return new Validator((value) => {
       if (value < 0) {
@@ -64,7 +64,7 @@ await test("Validator", async (t) => {
       }
     });
   }
-
+  
   function createAsyncValidator() {
     return new Validator(async (value) => {
       if (value < 0) {
@@ -72,148 +72,177 @@ await test("Validator", async (t) => {
       }
     });
   }
-
-  await t.test("constructor throws on non-function", () => {
+  
+  await ctx.test("constructor throws on non-function", () => {
     assert.throws(() => new Validator("not a function"), TypeError);
     assert.throws(() => new Validator(42), TypeError);
   });
-
-  await t.test(".validate() with valid input returns a valid result", () => {
+  
+  await ctx.test(".validate() with valid input returns a valid result", () => {
     const result = createValidator().validate(5);
     assert.equal(result.valid, true);
     assert.equal(result.value, 5);
   });
-
-  await t.test(".validate() with invalid input returns an invalid result", () => {
+  
+  await ctx.test(".validate() invalid input returns invalid result", () => {
     const result = createValidator().validate(-2);
     assert.equal(result.valid, false);
     assert.equal(result.errors.length, 1);
     assert.equal(result.errors.at(0).message, "Value must be non-negative");
   });
-
-  await t.test(".message() with a string overrides the error message", () => {
+  
+  await ctx.test(".message(string) overrides the error message", () => {
     const result = createValidator().message("Custom message").validate(-3);
     assert.equal(result.valid, false);
     assert.equal(result.errors.at(0).message, "Custom message");
   });
-
-  await t.test(".message() with a function overrides the error message", () => {
+  
+  await ctx.test(".message(fn) overrides the error message", () => {
     const result = createValidator().message(() => "From fn").validate(-3);
     assert.equal(result.valid, false);
     assert.equal(result.errors.at(0).message, "From fn");
   });
-
-  await t.test(".validateAsync() with valid input", async () => {
+  
+  await ctx.test(".validateAsync() with valid input", async () => {
     const result = await createAsyncValidator().validateAsync(5);
     assert.equal(result.valid, true);
     assert.equal(result.value, 5);
   });
-
-  await t.test(".validateAsync() with invalid input", async () => {
+  
+  await ctx.test(".validateAsync() with invalid input", async () => {
     const result = await createAsyncValidator().validateAsync(-2);
     assert.equal(result.valid, false);
     assert.equal(result.errors.length, 1);
   });
-
-  await t.test(".test() returns boolean validity", () => {
-    const v = createValidator();
-    assert.equal(v.test(5), true);
-    assert.equal(v.test(-2), false);
+  
+  await ctx.test(".test() returns boolean validity", () => {
+    const vld = createValidator();
+    assert.equal(vld.test(5), true);
+    assert.equal(vld.test(-2), false);
   });
-
-  await t.test(".testAsync() returns boolean validity", async () => {
-    const v = createAsyncValidator();
-    assert.equal(await v.testAsync(5), true);
-    assert.equal(await v.testAsync(-2), false);
+  
+  await ctx.test(".testAsync() returns boolean validity", async () => {
+    const vld = createAsyncValidator();
+    assert.equal(await vld.testAsync(5), true);
+    assert.equal(await vld.testAsync(-2), false);
   });
-
-  await t.test(".assert() with valid input doesn't throw", () => {
+  
+  await ctx.test(".assert() with valid input doesn't throw", () => {
     assert.doesNotThrow(() => createValidator().assert(5));
   });
-
-  await t.test(".assert() with invalid input throws", () => {
+  
+  await ctx.test(".assert() with invalid input throws", () => {
     assert.throws(() => createValidator().assert(-2), ValidationError);
   });
-
-  await t.test(".assertAsync() with valid input doesn't throw", async () => {
+  
+  await ctx.test(".assertAsync() with valid input doesn't throw", async () => {
     await assert.doesNotReject(() => createAsyncValidator().assertAsync(5));
   });
-
-  await t.test(".assertAsync() with invalid input throws", async () => {
+  
+  await ctx.test(".assertAsync() with invalid input throws", async () => {
     await assert.rejects(
       () => createAsyncValidator().assertAsync(-2),
       ValidationError,
     );
   });
-
-  await t.test("non-ValidationError throws bubble up", () => {
-    const v = new Validator(() => { throw new RangeError("boom"); });
-    assert.throws(() => v.validate(null));
+  
+  await ctx.test("non-ValidationError throws keep original type", () => {
+    const vld = new Validator(() => { throw new RangeError("boom"); });
+    assert.throws(() => vld.validate(null), (error) => {
+      return error instanceof RangeError && error.message === "boom";
+    });
+  });
+  
+  await ctx.test("mixed throw arrays become AggregateError", () => {
+    const vld = new Validator(() => {
+      throw [new RangeError("a"), new ValidationError("b")];
+    });
+    assert.throws(() => vld.validate(null), AggregateError);
+  });
+  
+  await ctx.test(".validate() throws TypeError on Promise return", () => {
+    const asyncFn = async (value) => value;
+    const vld = new Validator(asyncFn);
+    assert.throws(() => vld.validate(1), TypeError);
   });
 });
 
 
-await test("schema()", async (t) => {
-  await t.test("with valid input", () => {
+await test("schema()", async (ctx) => {
+  await ctx.test("with valid input", () => {
     const Name = schema(required(), minLength(3));
     const result = Name.validate("Alice");
     assert.equal(result.valid, true);
     assert.equal(result.value, "Alice");
   });
-
-  await t.test("accepts both plain functions and Validator instances", () => {
-    const plainFn = (v) => {
-      if (v !== "ok") throw new ValidationError("not ok");
+  
+  await ctx.test("accepts both plain functions and Validator instances", () => {
+    const plainFn = (vld) => {
+      if (vld !== "ok") throw new ValidationError("not ok");
     };
-    const vld = new Validator((v) => {
-      if (typeof v !== "string") throw new ValidationError("not string");
+    const vld = new Validator((vld) => {
+      if (typeof vld !== "string") throw new ValidationError("not string");
     });
-    const S = schema(plainFn, vld);
-    assert.equal(S.validate("ok").valid, true);
-    assert.equal(S.validate("nope").valid, false);
+    const Sch = schema(plainFn, vld);
+    assert.equal(Sch.validate("ok").valid, true);
+    assert.equal(Sch.validate("nope").valid, false);
   });
-
-  await t.test("throws TypeError on non-function argument", () => {
+  
+  await ctx.test("throws TypeError on non-function argument", () => {
     assert.throws(() => schema("not a fn"), TypeError);
   });
 });
 
 
-await test("key()", async (t) => {
+await test("key()", async (ctx) => {
   const UserSchema = schema(
     key("username", required(), minLength(3)),
     key("age", required()),
   );
-
-  await t.test("with valid input", () => {
+  
+  await ctx.test("with valid input", () => {
     const result = UserSchema.validate({ username: "alice", age: 30 });
     assert.equal(result.valid, true);
     assert.deepEqual(result.value, { username: "alice", age: 30 });
   });
-
-  await t.test("with missing key surfaces errors with paths", () => {
+  
+  await ctx.test("with missing key surfaces errors with paths", () => {
     const result = UserSchema.validate({ age: 30 });
     assert.equal(result.valid, false);
     assert.equal(result.errors.at(0) instanceof RequiredError, true);
     assert.deepEqual(result.errors.at(0).path, ["username"]);
   });
-
-  await t.test("nested key()s with valid input", () => {
+  
+  await ctx.test("nested key()s with valid input", () => {
     const Nested = schema(key("foo", key("bar", required())));
     const result = Nested.validate({ foo: { bar: 42 } });
     assert.equal(result.valid, true);
   });
-
-  await t.test("nested key()s propagate path", () => {
+  
+  await ctx.test("nested key()s propagate path", () => {
     const Nested = schema(key("foo", key("bar", required())));
     const result = Nested.validate({ foo: {} });
     assert.equal(result.valid, false);
     assert.deepEqual(result.errors.at(0).path, ["foo", "bar"]);
   });
+  
+  await ctx.test("null value produces ValidationError, not TypeError", () => {
+    const Sch = schema(key("foo", required()));
+    const result = Sch.validate(null);
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0) instanceof WrongTypeValidationError, true);
+  });
+  
+  await ctx.test("primitive value produces ValidationError", () => {
+    const Sch = schema(key("foo", required()));
+    const result = Sch.validate(42);
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0) instanceof WrongTypeValidationError, true);
+  });
 });
 
 
-await test("items()", async (t) => {
+await test("items()", async (ctx) => {
   function allCaps() {
     return new Validator((value) => {
       if (value !== value.toUpperCase()) {
@@ -221,21 +250,21 @@ await test("items()", async (t) => {
       }
     });
   }
-
+  
   const ListSchema = schema(items(allCaps()));
-
-  await t.test("with valid input", () => {
+  
+  await ctx.test("with valid input", () => {
     const result = ListSchema.validate(["FOO", "BAR", "BAZ"]);
     assert.equal(result.valid, true);
   });
-
-  await t.test("with invalid input at index 1", () => {
+  
+  await ctx.test("with invalid input at index 1", () => {
     const result = ListSchema.validate(["FOO", "Bar", "BAZ"]);
     assert.equal(result.valid, false);
     assert.deepEqual(result.errors.at(0).path, [1]);
   });
-
-  await t.test("rejects non-arrays", () => {
+  
+  await ctx.test("rejects non-arrays", () => {
     const result = ListSchema.validate("not an array");
     assert.equal(result.valid, false);
     assert.equal(result.errors.at(0) instanceof ValidationError, true);
@@ -243,107 +272,108 @@ await test("items()", async (t) => {
 });
 
 
-await test("hasKey()", async (t) => {
+await test("hasKey()", async (ctx) => {
   const UserSchema = schema(hasKey("username"));
-
-  await t.test("with key present", () => {
+  
+  await ctx.test("with key present", () => {
     const result = UserSchema.validate({ username: "alice" });
     assert.equal(result.valid, true);
   });
-
-  await t.test("with key missing", () => {
+  
+  await ctx.test("with key missing", () => {
     const result = UserSchema.validate({ name: "alice" });
     assert.equal(result.valid, false);
     assert.equal(result.errors.at(0) instanceof MissingKeyError, true);
   });
-
-  await t.test("with symbol key", () => {
+  
+  await ctx.test("with symbol key", () => {
     const sym = Symbol("k");
-    const S = schema(hasKey(sym));
-    assert.equal(S.validate({ [sym]: 1 }).valid, true);
-    assert.equal(S.validate({}).valid, false);
+    const Sch = schema(hasKey(sym));
+    assert.equal(Sch.validate({ [sym]: 1 }).valid, true);
+    assert.equal(Sch.validate({}).valid, false);
   });
-
-  await t.test("throws TypeError if key isn't a string or symbol", () => {
+  
+  await ctx.test("throws TypeError if key isn't a string or symbol", () => {
     assert.throws(() => hasKey(123), TypeError);
   });
 });
 
 
-await test("required()", async (t) => {
-  await t.test("with valid values", () => {
-    const v = required();
-    assert.equal(v.validate("hello").valid, true);
-    assert.equal(v.validate(0).valid, true);
-    assert.equal(v.validate(false).valid, true);
-    assert.equal(v.validate(true).valid, true);
+await test("required()", async (ctx) => {
+  await ctx.test("with valid values", () => {
+    const vld = required();
+    assert.equal(vld.validate("hello").valid, true);
+    assert.equal(vld.validate(0).valid, true);
+    assert.equal(vld.validate(false).valid, true);
+    assert.equal(vld.validate(true).valid, true);
   });
-
-  await t.test("with invalid values", () => {
-    const v = required();
-    assert.equal(v.validate(undefined).valid, false);
-    assert.equal(v.validate(null).valid, false);
-    assert.equal(v.validate("").valid, false);
-    assert.equal(v.validate([]).valid, false);
-    assert.equal(v.validate({}).valid, false);
-    assert.equal(v.validate(NaN).valid, false);
+  
+  await ctx.test("with invalid values", () => {
+    const vld = required();
+    assert.equal(vld.validate(undefined).valid, false);
+    assert.equal(vld.validate(null).valid, false);
+    assert.equal(vld.validate("").valid, false);
+    assert.equal(vld.validate([]).valid, false);
+    assert.equal(vld.validate({}).valid, false);
+    assert.equal(vld.validate(NaN).valid, false);
   });
-
-  await t.test("with nested validators", async (tt) => {
-    const S = schema(
+  
+  await ctx.test("with nested validators", async (inner) => {
+    const Sch = schema(
       required(type(Object), key("foo", string.minLength(3))),
     );
-
-    await tt.test("valid input passes", () => {
-      assert.equal(S.validate({ foo: "bar" }).valid, true);
+    
+    await inner.test("valid input passes", () => {
+      assert.equal(Sch.validate({ foo: "bar" }).valid, true);
     });
-
-    await tt.test("missing value throws RequiredError, inner skipped", () => {
-      const result = S.validate(null);
+    
+    await inner.test("missing throws RequiredError, inner skipped", () => {
+      const result = Sch.validate(null);
       assert.equal(result.valid, false);
       assert.equal(result.errors.length, 1);
       assert.equal(result.errors.at(0) instanceof RequiredError, true);
     });
-
-    await tt.test("present but invalid runs inner validators", () => {
-      const result = S.validate({ foo: "hi" });
+    
+    await inner.test("present but invalid runs inner validators", () => {
+      const result = Sch.validate({ foo: "hi" });
+      const firstError = result.errors.at(0);
       assert.equal(result.valid, false);
-      assert.equal(result.errors.at(0) instanceof MinimumStringLengthError, true);
-      assert.deepEqual(result.errors.at(0).path, ["foo"]);
+      assert.equal(firstError instanceof MinimumStringLengthError, true);
+      assert.deepEqual(firstError.path, ["foo"]);
     });
   });
 });
 
 
-await test("optional()", async (t) => {
-  const S = schema(optional(string.minLength(5)));
-
-  await t.test("empty values pass", () => {
-    assert.equal(S.validate(undefined).valid, true);
-    assert.equal(S.validate(null).valid, true);
-    assert.equal(S.validate("").valid, true);
+await test("optional()", async (ctx) => {
+  const Sch = schema(optional(string.minLength(5)));
+  
+  await ctx.test("empty values pass", () => {
+    assert.equal(Sch.validate(undefined).valid, true);
+    assert.equal(Sch.validate(null).valid, true);
+    assert.equal(Sch.validate("").valid, true);
   });
-
-  await t.test("non-empty valid value passes", () => {
-    assert.equal(S.validate("hello").valid, true);
+  
+  await ctx.test("non-empty valid value passes", () => {
+    assert.equal(Sch.validate("hello").valid, true);
   });
-
-  await t.test("non-empty invalid value fails", () => {
-    assert.equal(S.validate("hi").valid, false);
+  
+  await ctx.test("non-empty invalid value fails", () => {
+    assert.equal(Sch.validate("hi").valid, false);
   });
 });
 
 
-await test("type()", async (t) => {
-  await t.test("with valid input", () => {
+await test("type()", async (ctx) => {
+  await ctx.test("with valid input", () => {
     assert.equal(type(Object).validate({}).valid, true);
     assert.equal(type(Number).validate(42).valid, true);
     assert.equal(type(Array).validate([]).valid, true);
     assert.equal(type(String).validate("s").valid, true);
     assert.equal(type("string").validate("s").valid, true);
   });
-
-  await t.test("with invalid input", () => {
+  
+  await ctx.test("with invalid input", () => {
     assert.equal(type(Object).validate("hi").valid, false);
     assert.equal(type(Number).validate({}).valid, false);
     const result = type(Object).validate("hi");
@@ -355,187 +385,187 @@ await test("type()", async (t) => {
 });
 
 
-await test("type.oneOf()", async (t) => {
-  class A {}
-  class B {}
-  class C {}
-
-  const S = schema(type.oneOf(A, B, C));
-
-  await t.test("with valid input", () => {
-    assert.equal(S.validate(new A()).valid, true);
-    assert.equal(S.validate(new B()).valid, true);
-    assert.equal(S.validate(new C()).valid, true);
+await test("type.oneOf()", async (ctx) => {
+  class AKind {}
+  class BKind {}
+  class CKind {}
+  
+  const Sch = schema(type.oneOf(AKind, BKind, CKind));
+  
+  await ctx.test("with valid input", () => {
+    assert.equal(Sch.validate(new AKind()).valid, true);
+    assert.equal(Sch.validate(new BKind()).valid, true);
+    assert.equal(Sch.validate(new CKind()).valid, true);
   });
-
-  await t.test("with invalid input", () => {
-    assert.equal(S.validate("hello").valid, false);
-    assert.equal(S.validate(null).valid, false);
-    assert.equal(S.validate(undefined).valid, false);
+  
+  await ctx.test("with invalid input", () => {
+    assert.equal(Sch.validate("hello").valid, false);
+    assert.equal(Sch.validate(null).valid, false);
+    assert.equal(Sch.validate(undefined).valid, false);
   });
 });
 
 
-await test("type.to()", async (t) => {
-  await t.test("to Boolean", () => {
+await test("type.to()", async (ctx) => {
+  await ctx.test("to Boolean", () => {
     assert.equal(type.to(Boolean).validate("foo").value, true);
     assert.equal(type.to(Boolean).validate("").value, false);
   });
-
-  await t.test("to String", () => {
+  
+  await ctx.test("to String", () => {
     assert.equal(type.to(String).validate(42).value, "42");
     assert.equal(type.to(String).validate(0).value, "0");
     assert.equal(type.to(String).validate([1, 2, 3]).value, "1,2,3");
   });
-
-  await t.test("numeric string to Number", () => {
-    const r = type.to(Number).validate("42");
-    assert.equal(r.valid, true);
-    assert.equal(r.value, 42);
+  
+  await ctx.test("numeric string to Number", () => {
+    const res = type.to(Number).validate("42");
+    assert.equal(res.valid, true);
+    assert.equal(res.value, 42);
   });
-
-  await t.test("non-numeric string to Number is NaN but still valid", () => {
-    const r = type.to(Number).validate("not-a-number");
-    assert.equal(r.valid, true);
-    assert.equal(Number.isNaN(r.value), true);
+  
+  await ctx.test("non-numeric string to Number is NaN but still valid", () => {
+    const res = type.to(Number).validate("not-a-number");
+    assert.equal(res.valid, true);
+    assert.equal(Number.isNaN(res.value), true);
   });
-
-  await t.test("to Object wraps null", () => {
-    const r = type.to(Object).validate(null);
-    assert.deepEqual(r.value, {});
+  
+  await ctx.test("to Object wraps null", () => {
+    const res = type.to(Object).validate(null);
+    assert.deepEqual(res.value, {});
   });
-
-  await t.test("to Array", () => {
-    const r = type.to(Array).validate("foo");
-    assert.deepEqual(r.value, ["f", "o", "o"]);
+  
+  await ctx.test("to Array", () => {
+    const res = type.to(Array).validate("foo");
+    assert.deepEqual(res.value, ["f", "o", "o"]);
   });
-
-  await t.test("to Date", () => {
-    const r = type.to(Date).validate("2021-01-01");
-    assert.equal(r.value instanceof Date, true);
-    assert.equal(Number.isNaN(r.value.getTime()), false);
+  
+  await ctx.test("to Date", () => {
+    const res = type.to(Date).validate("2021-01-01");
+    assert.equal(res.value instanceof Date, true);
+    assert.equal(Number.isNaN(res.value.getTime()), false);
   });
-
-  await t.test("to BigInt", () => {
-    const r = type.to(BigInt).validate("42");
-    assert.equal(r.value, 42n);
+  
+  await ctx.test("to BigInt", () => {
+    const res = type.to(BigInt).validate("42");
+    assert.equal(res.value, 42n);
   });
-
-  await t.test("unsupported type throws TypeError", () => {
+  
+  await ctx.test("unsupported type throws TypeError", () => {
     assert.throws(() => type.to("banana"), TypeError);
   });
 });
 
 
-await test("oneOf()", async (t) => {
-  const S = schema(oneOf("red", "green", "blue"));
-
-  await t.test("with valid input", () => {
-    assert.equal(S.validate("red").valid, true);
-    assert.equal(S.validate("green").valid, true);
+await test("oneOf()", async (ctx) => {
+  const Sch = schema(oneOf("red", "green", "blue"));
+  
+  await ctx.test("with valid input", () => {
+    assert.equal(Sch.validate("red").valid, true);
+    assert.equal(Sch.validate("green").valid, true);
   });
-
-  await t.test("with invalid input", () => {
-    const result = S.validate("yellow");
+  
+  await ctx.test("with invalid input", () => {
+    const result = Sch.validate("yellow");
     assert.equal(result.valid, false);
     assert.equal(result.errors.at(0) instanceof ValidationError, true);
   });
 });
 
 
-await test("minLength() (generic)", async (t) => {
-  await t.test("with valid values", () => {
-    const v = minLength(5);
-    assert.equal(v.validate("hello").valid, true);
-    assert.equal(v.validate(["h", "e", "l", "l", "o"]).valid, true);
+await test("minLength() (generic)", async (ctx) => {
+  await ctx.test("with valid values", () => {
+    const vld = minLength(5);
+    assert.equal(vld.validate("hello").valid, true);
+    assert.equal(vld.validate(["h", "e", "l", "l", "o"]).valid, true);
   });
-
-  await t.test("with invalid values", () => {
-    const v = minLength(5);
-    assert.equal(v.validate("hi").valid, false);
-    assert.equal(v.validate(["h", "i"]).valid, false);
+  
+  await ctx.test("with invalid values", () => {
+    const vld = minLength(5);
+    assert.equal(vld.validate("hi").valid, false);
+    assert.equal(vld.validate(["h", "i"]).valid, false);
   });
-
-  await t.test("with message override reading details", () => {
-    const v = minLength(3).message(
+  
+  await ctx.test("with message override reading details", () => {
+    const vld = minLength(3).message(
       (error) => `Must be at least ${error.details.minLength} chars`,
     );
-    const result = v.validate("a");
+    const result = vld.validate("a");
     assert.equal(result.errors.at(0).message, "Must be at least 3 chars");
   });
-
-  await t.test("rejects values without numeric length", () => {
-    const v = minLength(3);
-    assert.equal(v.validate(42).valid, false);
+  
+  await ctx.test("rejects values without numeric length", () => {
+    const vld = minLength(3);
+    assert.equal(vld.validate(42).valid, false);
   });
 });
 
 
 await test("string.minLength()", async () => {
-  const S = schema(string.minLength(3));
-  assert.equal(S.validate("hello").valid, true);
-  const result = S.validate("hi");
+  const Sch = schema(string.minLength(3));
+  assert.equal(Sch.validate("hello").valid, true);
+  const result = Sch.validate("hi");
   assert.equal(result.valid, false);
   assert.equal(result.errors.at(0) instanceof MinimumStringLengthError, true);
 });
 
 
 await test("string.maxLength()", async () => {
-  const S = schema(string.maxLength(5));
-  assert.equal(S.validate("hello").valid, true);
-  const result = S.validate("hello world");
+  const Sch = schema(string.maxLength(5));
+  assert.equal(Sch.validate("hello").valid, true);
+  const result = Sch.validate("hello world");
   assert.equal(result.valid, false);
   assert.equal(result.errors.at(0) instanceof MaximumStringLengthError, true);
 });
 
 
-await test("string.url()", async (t) => {
-  const S = schema(string.url());
-
-  await t.test("bare domain", () => {
-    assert.equal(S.validate("example.com").valid, true);
+await test("string.url()", async (ctx) => {
+  const Sch = schema(string.url());
+  
+  await ctx.test("bare domain", () => {
+    assert.equal(Sch.validate("example.com").valid, true);
   });
-
-  await t.test("full URL", () => {
-    assert.equal(S.validate("https://example.com/path").valid, true);
+  
+  await ctx.test("full URL", () => {
+    assert.equal(Sch.validate("https://example.com/path").valid, true);
   });
-
-  await t.test("URL with port", () => {
-    assert.equal(S.validate("https://example.com:8080").valid, true);
+  
+  await ctx.test("URL with port", () => {
+    assert.equal(Sch.validate("https://example.com:8080").valid, true);
   });
-
-  await t.test("subdomain accepted", () => {
-    assert.equal(S.validate("api.example.com").valid, true);
+  
+  await ctx.test("subdomain accepted", () => {
+    assert.equal(Sch.validate("api.example.com").valid, true);
   });
-
-  await t.test("IP address rejected", () => {
-    assert.equal(S.validate("192.168.1.1").valid, false);
+  
+  await ctx.test("IP address rejected", () => {
+    assert.equal(Sch.validate("192.168.1.1").valid, false);
   });
-
-  await t.test("localhost rejected (not listed public domain)", () => {
-    assert.equal(S.validate("localhost").valid, false);
+  
+  await ctx.test("localhost rejected (not listed public domain)", () => {
+    assert.equal(Sch.validate("localhost").valid, false);
   });
-
-  await t.test("empty string rejected", () => {
-    const result = S.validate("");
+  
+  await ctx.test("empty string rejected", () => {
+    const result = Sch.validate("");
     assert.equal(result.valid, false);
     assert.equal(result.errors.at(0) instanceof InvalidURLError, true);
   });
-
-  await t.test("garbage rejected", () => {
-    assert.equal(S.validate("not-a-url").valid, false);
+  
+  await ctx.test("garbage rejected", () => {
+    assert.equal(Sch.validate("not-a-url").valid, false);
   });
 });
 
 
-await test("string.email()", async (t) => {
-  const S = schema(string.email());
-
-  await t.test("with valid input", () => {
-    assert.equal(S.validate("user@example.com").valid, true);
+await test("string.email()", async (ctx) => {
+  const Sch = schema(string.email());
+  
+  await ctx.test("with valid input", () => {
+    assert.equal(Sch.validate("user@example.com").valid, true);
   });
-
-  await t.test("with invalid inputs", () => {
+  
+  await ctx.test("with invalid inputs", () => {
     const invalid = [
       "not-an-email",
       "user@example",
@@ -551,152 +581,232 @@ await test("string.email()", async (t) => {
       null,
       undefined,
     ];
-    for (const v of invalid) {
-      assert.equal(S.validate(v).valid, false, `expected invalid: ${v}`);
+    for (const vld of invalid) {
+      assert.equal(Sch.validate(vld).valid, false, `expected invalid: ${vld}`);
     }
-    const result = S.validate("bad");
+    const result = Sch.validate("bad");
     assert.equal(result.errors.at(0) instanceof InvalidEmailError, true);
   });
 });
 
 
-await test("string.isoDate()", async (t) => {
-  const S = schema(string.isoDate());
-
-  await t.test("valid dates", () => {
-    assert.equal(S.validate("2024-01-01").valid, true);
-    assert.equal(S.validate("2024-12-31").valid, true);
-    assert.equal(S.validate("2024-02-29").valid, true); // leap year
-    assert.equal(S.validate("2023-08-22").valid, true);
+await test("string.isoDate()", async (ctx) => {
+  const Sch = schema(string.isoDate());
+  
+  await ctx.test("valid dates", () => {
+    assert.equal(Sch.validate("2024-01-01").valid, true);
+    assert.equal(Sch.validate("2024-12-31").valid, true);
+    assert.equal(Sch.validate("2024-02-29").valid, true); // leap year
+    assert.equal(Sch.validate("2023-08-22").valid, true);
   });
-
-  await t.test("invalid format", () => {
-    assert.equal(S.validate("2024-1-1").valid, false);
-    assert.equal(S.validate("24-01-01").valid, false);
-    assert.equal(S.validate("2024/01/01").valid, false);
-    assert.equal(S.validate("").valid, false);
-    assert.equal(S.validate("08/22/2023").valid, false);
-    assert.equal(S.validate("22-08-2023").valid, false);
-    const result = S.validate("");
+  
+  await ctx.test("invalid format", () => {
+    assert.equal(Sch.validate("2024-1-1").valid, false);
+    assert.equal(Sch.validate("24-01-01").valid, false);
+    assert.equal(Sch.validate("2024/01/01").valid, false);
+    assert.equal(Sch.validate("").valid, false);
+    assert.equal(Sch.validate("08/22/2023").valid, false);
+    assert.equal(Sch.validate("22-08-2023").valid, false);
+    const result = Sch.validate("");
     assert.equal(result.errors.at(0) instanceof InvalidISODateError, true);
   });
-
-  await t.test("invalid rollover dates rejected", () => {
-    assert.equal(S.validate("2024-02-30").valid, false);
-    assert.equal(S.validate("2024-13-01").valid, false);
-    assert.equal(S.validate("2023-02-29").valid, false); // non-leap
-    assert.equal(S.validate("2023-12-32").valid, false);
-    assert.equal(S.validate("2024-04-31").valid, false);
-    assert.equal(S.validate("2023-22-08").valid, false);
+  
+  await ctx.test("invalid rollover dates rejected", () => {
+    assert.equal(Sch.validate("2024-02-30").valid, false);
+    assert.equal(Sch.validate("2024-13-01").valid, false);
+    assert.equal(Sch.validate("2023-02-29").valid, false); // non-leap
+    assert.equal(Sch.validate("2023-12-32").valid, false);
+    assert.equal(Sch.validate("2024-04-31").valid, false);
+    assert.equal(Sch.validate("2023-22-08").valid, false);
   });
-
-  await t.test("non-string rejected", () => {
-    assert.equal(S.validate(42).valid, false);
-    assert.equal(S.validate(null).valid, false);
+  
+  await ctx.test("non-string rejected", () => {
+    assert.equal(Sch.validate(42).valid, false);
+    assert.equal(Sch.validate(null).valid, false);
   });
 });
 
 
 await test("number.min()", async () => {
-  const S = schema(number.min(10));
-  assert.equal(S.validate(15).valid, true);
-  const result = S.validate(5);
+  const Sch = schema(number.min(10));
+  assert.equal(Sch.validate(15).valid, true);
+  const result = Sch.validate(5);
   assert.equal(result.valid, false);
   assert.equal(result.errors.at(0) instanceof MinimumNumberError, true);
 });
 
 
 await test("number.max()", async () => {
-  const S = schema(number.max(20));
-  assert.equal(S.validate(15).valid, true);
-  const result = S.validate(25);
+  const Sch = schema(number.max(20));
+  assert.equal(Sch.validate(15).valid, true);
+  const result = Sch.validate(25);
   assert.equal(result.valid, false);
   assert.equal(result.errors.at(0) instanceof MaximumNumberError, true);
 });
 
 
 await test("number.finite()", async () => {
-  const S = schema(number.finite());
-  assert.equal(S.validate(42).valid, true);
-  const result = S.validate(Infinity);
+  const Sch = schema(number.finite());
+  assert.equal(Sch.validate(42).valid, true);
+  const result = Sch.validate(Infinity);
   assert.equal(result.valid, false);
   assert.equal(result.errors.at(0) instanceof FiniteNumberError, true);
 });
 
 
 await test("number.integer()", async () => {
-  const S = schema(number.integer());
-  assert.equal(S.validate(42).valid, true);
-  const result = S.validate(42.5);
+  const Sch = schema(number.integer());
+  assert.equal(Sch.validate(42).valid, true);
+  const result = Sch.validate(42.5);
   assert.equal(result.valid, false);
   assert.equal(result.errors.at(0) instanceof NonIntegerError, true);
 });
 
 
 await test("number.positive()", async () => {
-  const S = schema(number.positive());
-  assert.equal(S.validate(42).valid, true);
-  assert.equal(S.validate(0).valid, false);
-  assert.equal(S.validate(-5).valid, false);
-  const result = S.validate(0);
+  const Sch = schema(number.positive());
+  assert.equal(Sch.validate(42).valid, true);
+  assert.equal(Sch.validate(0).valid, false);
+  assert.equal(Sch.validate(-5).valid, false);
+  const result = Sch.validate(0);
   assert.equal(result.errors.at(0) instanceof PositiveNumberError, true);
 });
 
 
 await test("number.nonNegative()", async () => {
-  const S = schema(number.nonNegative());
-  assert.equal(S.validate(42).valid, true);
-  assert.equal(S.validate(0).valid, true);
-  assert.equal(S.validate(-5).valid, false);
-  const result = S.validate(-1);
+  const Sch = schema(number.nonNegative());
+  assert.equal(Sch.validate(42).valid, true);
+  assert.equal(Sch.validate(0).valid, true);
+  assert.equal(Sch.validate(-5).valid, false);
+  const result = Sch.validate(-1);
   assert.equal(result.errors.at(0) instanceof NonNegativeNumberError, true);
 });
 
 
-await test("isEmpty()", async (t) => {
-  await t.test("primitives are never empty", () => {
+await test("isEmpty()", async (ctx) => {
+  await ctx.test("primitives are never empty", () => {
     assert.equal(isEmpty(0), false);
     assert.equal(isEmpty(false), false);
     assert.equal(isEmpty("x"), false);
     assert.equal(isEmpty(42), false);
   });
-
-  await t.test("strings/arrays use .length", () => {
+  
+  await ctx.test("strings/arrays use .length", () => {
     assert.equal(isEmpty(""), false); // string is primitive
     assert.equal(isEmpty([]), true);
     assert.equal(isEmpty([1]), false);
   });
-
-  await t.test("Maps/Sets use .size", () => {
+  
+  await ctx.test("Maps/Sets use .size", () => {
     assert.equal(isEmpty(new Map()), true);
     assert.equal(isEmpty(new Map([["a", 1]])), false);
     assert.equal(isEmpty(new Set()), true);
     assert.equal(isEmpty(new Set([1])), false);
   });
-
-  await t.test("plain objects check enumerable properties", () => {
+  
+  await ctx.test("plain objects check enumerable properties", () => {
     assert.equal(isEmpty({}), true);
     assert.equal(isEmpty({ a: 1 }), false);
   });
 });
 
 
-await test("mapAdapter()", async (t) => {
-  await t.test("returns a Validator", () => {
-    const v = mapAdapter((x) => x * 2);
-    assert.equal(v instanceof Validator, true);
+await test("async composition", async (ctx) => {
+  function asyncNotZero() {
+    return new Validator(async (value) => {
+      await Promise.resolve();
+      if (value === 0) throw new ValidationError("Must not be zero");
+    });
+  }
+  
+  await ctx.test("schema() awaits async child validators", async () => {
+    const Sch = schema(asyncNotZero());
+    const result = await Sch.validateAsync(0);
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.at(0).message, "Must not be zero");
   });
+  
+  await ctx.test("schema() sync validate throws on async child", () => {
+    const Sch = schema(asyncNotZero());
+    assert.throws(() => Sch.validate(0), TypeError);
+  });
+  
+  await ctx.test("key() awaits async validators", async () => {
+    const Sch = schema(key("n", asyncNotZero()));
+    const ok = await Sch.validateAsync({ n: 1 });
+    assert.equal(ok.valid, true);
+    const bad = await Sch.validateAsync({ n: 0 });
+    assert.equal(bad.valid, false);
+    assert.deepEqual(bad.errors.at(0).path, ["n"]);
+  });
+  
+  await ctx.test("items() awaits async validators", async () => {
+    const Sch = schema(items(asyncNotZero()));
+    const bad = await Sch.validateAsync([1, 0, 2]);
+    assert.equal(bad.valid, false);
+    assert.deepEqual(bad.errors.at(0).path, [1]);
+  });
+  
+  await ctx.test("required() awaits async inner validators", async () => {
+    const Sch = schema(required(asyncNotZero()));
+    const bad = await Sch.validateAsync(0);
+    assert.equal(bad.valid, false);
+  });
+  
+  await ctx.test("optional() awaits async inner validators", async () => {
+    const Sch = schema(optional(asyncNotZero()));
+    const missing = await Sch.validateAsync(undefined);
+    assert.equal(missing.valid, true);
+    const bad = await Sch.validateAsync(0);
+    assert.equal(bad.valid, false);
+  });
+});
 
-  await t.test("transforms the value when fn returns non-undefined", () => {
-    const v = mapAdapter((x) => x * 2);
-    const result = v.validate(5);
+
+await test("string.* type guards", async (ctx) => {
+  await ctx.test("string.minLength rejects non-strings", () => {
+    assert.equal(string.minLength(3).validate(42).valid, false);
+    assert.equal(string.minLength(3).validate(null).valid, false);
+    assert.equal(string.minLength(3).validate(undefined).valid, false);
+  });
+  
+  await ctx.test("string.maxLength rejects non-strings", () => {
+    assert.equal(string.maxLength(3).validate(42).valid, false);
+    assert.equal(string.maxLength(3).validate(null).valid, false);
+  });
+});
+
+
+await test("number.* type guards", async (ctx) => {
+  await ctx.test("number.min rejects non-numbers and NaN", () => {
+    assert.equal(number.min(1).validate("5").valid, false);
+    assert.equal(number.min(1).validate(NaN).valid, false);
+    assert.equal(number.min(1).validate(null).valid, false);
+  });
+  
+  await ctx.test("number.max rejects non-numbers and NaN", () => {
+    assert.equal(number.max(5).validate("1").valid, false);
+    assert.equal(number.max(5).validate(NaN).valid, false);
+  });
+});
+
+
+await test("mapAdapter()", async (ctx) => {
+  await ctx.test("returns a Validator", () => {
+    const vld = mapAdapter((num) => num * 2);
+    assert.equal(vld instanceof Validator, true);
+  });
+  
+  await ctx.test("transforms the value when fn returns non-undefined", () => {
+    const vld = mapAdapter((num) => num * 2);
+    const result = vld.validate(5);
     assert.equal(result.valid, true);
     assert.equal(result.value, 10);
   });
-
-  await t.test("passes value through when fn returns undefined", () => {
-    const v = mapAdapter(() => undefined);
-    const result = v.validate(5);
+  
+  await ctx.test("passes value through when fn returns undefined", () => {
+    const vld = mapAdapter(() => undefined);
+    const result = vld.validate(5);
     assert.equal(result.valid, true);
     assert.equal(result.value, 5);
   });


### PR DESCRIPTION
## Summary

Breaking rewrite to 1.0.0. Replaces the `(value, update, error)` function pipeline with a `Validator` class architecture, adds typed error subclasses, and introduces `string.*` / `number.*` namespaces. Runtime dependencies shrink from three to one.

Closes #9.

## What's new

- **`Validator` class** with `.message(str|fn)` chaining, and `validate` / `validateAsync` / `test` / `testAsync` / `assert` / `assertAsync` methods
- **Typed `ValidationError` subclasses**: `RequiredError`, `MinLengthError`, `MinimumStringLengthError`, `MaximumStringLengthError`, `MissingKeyError`, `WrongTypeValidationError`, `InvalidURLError`, `InvalidEmailError`, `InvalidISODateError`, `MinimumNumberError`, `MaximumNumberError`, `FiniteNumberError`, `NonIntegerError`, `PositiveNumberError`, `NonNegativeNumberError`
- **`ValidationResult`** with `.ok(value)` / `.error(errors)` static factories
- **`optional(...fns)`** — skip when value is `undefined` / `null` / `""`
- **Upgraded `required(...fns)`** — accepts inner validators; treats `NaN`, empty strings, length-0 / size-0 collections, and `isEmpty(value)` as missing
- **`type(Type)`** — unified type check across classes, type strings, and primitive constructors
- **`type.to(Type)`** — coercion via a built-in map for Array / BigInt / Boolean / Date / Function / Map / Number / Object / Promise / RegExp / Set / String / Symbol / Uint8Array
- **`type.oneOf(...Types)`** — `instanceof`-based union check
- **`oneOf(...values)`** — tested membership check
- **`string.*`** — `string()`, `string.minLength`, `string.maxLength`, `string.url`, `string.email`, `string.isoDate`
- **`number.*`** — `number()`, `number.min`, `number.max`, `number.finite`, `number.integer`, `number.positive`, `number.nonNegative`
- **`minLength(n)`** — generic length-based check for any value with numeric `.length`
- **`isEmpty(value)`** — handles primitives, `.length`, `.size`, iterables, enumerables
- **`hasKey(key)`** — singular (was `hasKeys(...keys)`); supports symbol keys

## Breaking changes

No backwards-compat shims. Call sites on `0.1.x` must migrate.

| Removed / renamed | Replacement |
| --- | --- |
| `isType(T)` / `is(T)` | `type(T)` |
| `as(T)` / `to(T)` | `type.to(T)` |
| `isOneOf(...v)` | `oneOf(...v)` |
| `isUrl()` | `string.url()` |
| `length(min, max)` | `string.minLength(min)` + `string.maxLength(max)` |
| `hasKeys(...keys)` | one `hasKey(key)` per key |
| `(value, update, error)` handler | `new Validator(fn)` or plain `fn` in `schema()` that returns the new value |
| plain error objects with `code` | `ValidationError` subclass instances |

`mapAdapter` is preserved as a thin alias: `mapAdapter = (fn) => new Validator(fn)`. Existing call sites keep working.

Migration notes live in `README.md`.

## Dependencies

- **Removed:** `is`, `url-parse-lax`
- **Kept:** `parse-domain`
- **Not added:** `luxon`, `prepend-http`. Both replaced with native implementations (`string.isoDate()` uses a regex + round-trip through `Date`; `string.url()` inlines a small `prependHttp` helper and uses `new URL(...)` + `parseDomain()`).

## Test plan

- [x] `npm test` passes (107 subtests, 0 failures)
- [ ] Manual smoke: install in a downstream consumer and exercise `schema()`, `key()`, `required()`, `string.url()`, `string.isoDate()`, `type.to()`